### PR TITLE
Flexible Json Base Types

### DIFF
--- a/RareCpp/Main.cpp
+++ b/RareCpp/Main.cpp
@@ -204,6 +204,13 @@ Car outputExamples()
     sub.otherVal = 2;
     sub.subVal = 3;
     std::cout << Json::pretty(sub) << std::endl;
+
+    std::map<std::string, int> myMap { {"myMap", 1}, {"a", 2} };
+    std::tuple<std::string, int> myTuple { "myTuple", 3 };
+    std::vector<std::string> myVector { "myVector", "b", "c", "d" };
+    std::cout << Json::pretty(myMap) << std::endl;
+    std::cout << Json::pretty(myTuple) << std::endl;
+    std::cout << Json::pretty(myVector) << std::endl;
     
     SubTest::Supers::ForEach(sub, [&](auto superInfo, auto & superObj) {
         using SuperInfo = decltype(superInfo);

--- a/RareCpp/Main.cpp
+++ b/RareCpp/Main.cpp
@@ -31,7 +31,7 @@ Json::OutStreamType & operator<<(Json::OutStreamType & os, const A::TestEnum & t
 
 std::istream & operator>>(std::istream & is, A::TestEnum & testEnum)
 {
-    std::string input = Json::Read::String(is);
+    std::string input = Json::Read::String<>(is);
     auto found = A::TestEnumCache.find(input);
     if ( found != A::TestEnumCache.end() )
         testEnum = found->second;

--- a/RareCpp/Main.h
+++ b/RareCpp/Main.h
@@ -114,7 +114,7 @@ struct Json::Input::Customize<A, A::TestEnum, FieldIndex>
 {
     static bool As(std::istream & is, Context & context, const A & object, A::TestEnum & value)
     {
-        std::string input = Json::Read::String(is);
+        std::string input = Json::Read::String<>(is);
         auto found = A::TestEnumCacheCustom.find(input);
         if ( found != A::TestEnumCacheCustom.end() )
         {

--- a/RareCppTest/JsonInputTest.cpp
+++ b/RareCppTest/JsonInputTest.cpp
@@ -954,20 +954,76 @@ TEST_HEADER(JsonInputRead, StringToStream)
     std::stringstream tabStrReceiver;
     std::stringstream unicodeCharacterStrReceiver;
     std::stringstream everythingReceiver;
-    
-    Json::Read::String(emptyStr, c, emptyStrReceiver);
-    Json::Read::String(basicStr, c, basicStrReceiver);
-    Json::Read::String(quoteStr, c, quoteStrReceiver);
-    Json::Read::String(backslashStr, c, backslashStrReceiver);
-    Json::Read::String(forwardslashStr, c, forwardslashStrReceiver);
-    Json::Read::String(backspaceStr, c, backspaceStrReceiver);
-    Json::Read::String(formFeedStr, c, formFeedStrReceiver);
-    Json::Read::String(lineFeedStr, c, lineFeedStrReceiver);
-    Json::Read::String(carriageReturnStr, c, carriageReturnStrReceiver);
-    Json::Read::String(tabStr, c, tabStrReceiver);
-    Json::Read::String(unicodeCharacterStr, c, unicodeCharacterStrReceiver);
-    Json::Read::String(everything, c, everythingReceiver);
-    
+
+    Json::Read::String<>(emptyStr, c, emptyStrReceiver);
+    Json::Read::String<>(basicStr, c, basicStrReceiver);
+    Json::Read::String<>(quoteStr, c, quoteStrReceiver);
+    Json::Read::String<>(backslashStr, c, backslashStrReceiver);
+    Json::Read::String<>(forwardslashStr, c, forwardslashStrReceiver);
+    Json::Read::String<>(backspaceStr, c, backspaceStrReceiver);
+    Json::Read::String<>(formFeedStr, c, formFeedStrReceiver);
+    Json::Read::String<>(lineFeedStr, c, lineFeedStrReceiver);
+    Json::Read::String<>(carriageReturnStr, c, carriageReturnStrReceiver);
+    Json::Read::String<>(tabStr, c, tabStrReceiver);
+    Json::Read::String<>(unicodeCharacterStr, c, unicodeCharacterStrReceiver);
+    Json::Read::String<>(everything, c, everythingReceiver);
+
+    EXPECT_STREQ("", emptyStrReceiver.str().c_str());
+    EXPECT_STREQ("asdf", basicStrReceiver.str().c_str());
+    EXPECT_STREQ("\"", quoteStrReceiver.str().c_str());
+    EXPECT_STREQ("\\", backslashStrReceiver.str().c_str());
+    EXPECT_STREQ("/", forwardslashStrReceiver.str().c_str());
+    EXPECT_STREQ("\b", backspaceStrReceiver.str().c_str());
+    EXPECT_STREQ("\f", formFeedStrReceiver.str().c_str());
+    EXPECT_STREQ("\n", lineFeedStrReceiver.str().c_str());
+    EXPECT_STREQ("\r", carriageReturnStrReceiver.str().c_str());
+    EXPECT_STREQ("\t", tabStrReceiver.str().c_str());
+    EXPECT_STREQ("0", unicodeCharacterStrReceiver.str().c_str());
+    EXPECT_STREQ(" asdf \"\\/\b\f\n\r\t0 ", everythingReceiver.str().c_str());
+}
+
+TEST_HEADER(JsonInputRead, UnquotedStringToStream)
+{
+    char c = '\0';
+    std::stringstream emptyStr("");
+    std::stringstream basicStr("asdf");
+    std::stringstream quoteStr("\\\"");
+    std::stringstream backslashStr("\\\\");
+    std::stringstream forwardslashStr("\\/");
+    std::stringstream backspaceStr("\\b");
+    std::stringstream formFeedStr("\\f");
+    std::stringstream lineFeedStr("\\n");
+    std::stringstream carriageReturnStr("\\r");
+    std::stringstream tabStr("\\t");
+    std::stringstream unicodeCharacterStr("\\u0030");
+    std::stringstream everything(" asdf \\\"\\\\\\/\\b\\f\\n\\r\\t\\u0030 ");
+
+    std::stringstream emptyStrReceiver;
+    std::stringstream basicStrReceiver;
+    std::stringstream quoteStrReceiver;
+    std::stringstream backslashStrReceiver;
+    std::stringstream forwardslashStrReceiver;
+    std::stringstream backspaceStrReceiver;
+    std::stringstream formFeedStrReceiver;
+    std::stringstream lineFeedStrReceiver;
+    std::stringstream carriageReturnStrReceiver;
+    std::stringstream tabStrReceiver;
+    std::stringstream unicodeCharacterStrReceiver;
+    std::stringstream everythingReceiver;
+
+    Json::Read::String<false>(emptyStr, c, emptyStrReceiver);
+    Json::Read::String<false>(basicStr, c, basicStrReceiver);
+    Json::Read::String<false>(quoteStr, c, quoteStrReceiver);
+    Json::Read::String<false>(backslashStr, c, backslashStrReceiver);
+    Json::Read::String<false>(forwardslashStr, c, forwardslashStrReceiver);
+    Json::Read::String<false>(backspaceStr, c, backspaceStrReceiver);
+    Json::Read::String<false>(formFeedStr, c, formFeedStrReceiver);
+    Json::Read::String<false>(lineFeedStr, c, lineFeedStrReceiver);
+    Json::Read::String<false>(carriageReturnStr, c, carriageReturnStrReceiver);
+    Json::Read::String<false>(tabStr, c, tabStrReceiver);
+    Json::Read::String<false>(unicodeCharacterStr, c, unicodeCharacterStrReceiver);
+    Json::Read::String<false>(everything, c, everythingReceiver);
+
     EXPECT_STREQ("", emptyStrReceiver.str().c_str());
     EXPECT_STREQ("asdf", basicStrReceiver.str().c_str());
     EXPECT_STREQ("\"", quoteStrReceiver.str().c_str());
@@ -987,7 +1043,16 @@ TEST_HEADER(JsonInputRead, StringReference)
     char c = '\0';
     std::stringstream everything("\" asdf \\\"\\\\\\/\\b\\f\\n\\r\\t\\u0030 \"");
     std::string result;
-    Json::Read::String(everything, c, result);
+    Json::Read::String<>(everything, c, result);
+    EXPECT_STREQ(" asdf \"\\/\b\f\n\r\t0 ", result.c_str());
+}
+
+TEST_HEADER(JsonInputRead, StringReferenceUnquoted)
+{
+    char c = '\0';
+    std::stringstream everything(" asdf \\\"\\\\\\/\\b\\f\\n\\r\\t\\u0030 ");
+    std::string result;
+    Json::Read::String<false>(everything, c, result);
     EXPECT_STREQ(" asdf \"\\/\b\f\n\r\t0 ", result.c_str());
 }
 
@@ -996,7 +1061,16 @@ TEST_HEADER(JsonInputRead, StringTemplate)
     char c = '\0';
     std::stringstream integerStream("\"1234\"");
     int result = 0;
-    Json::Read::String(integerStream, c, result);
+    Json::Read::String<>(integerStream, c, result);
+    EXPECT_EQ(1234, result);
+}
+
+TEST_HEADER(JsonInputRead, StringTemplateUnquoted)
+{
+    char c = '\0';
+    std::stringstream integerStream("1234");
+    int result = 0;
+    Json::Read::String<int, false>(integerStream, c, result);
     EXPECT_EQ(1234, result);
 }
 
@@ -1004,14 +1078,29 @@ TEST_HEADER(JsonInputRead, StringCharReturned)
 {
     char c = '\0';
     std::stringstream everything("\" asdf \\\"\\\\\\/\\b\\f\\n\\r\\t\\u0030 \"");
-    std::string result = Json::Read::String(everything, c);
+    std::string result = Json::Read::String<>(everything, c);
+    EXPECT_STREQ(" asdf \"\\/\b\f\n\r\t0 ", result.c_str());
+}
+
+TEST_HEADER(JsonInputRead, StringCharReturnedUnquoted)
+{
+    char c = '\0';
+    std::stringstream everything(" asdf \\\"\\\\\\/\\b\\f\\n\\r\\t\\u0030 ");
+    std::string result = Json::Read::String<false>(everything, c);
     EXPECT_STREQ(" asdf \"\\/\b\f\n\r\t0 ", result.c_str());
 }
 
 TEST_HEADER(JsonInputRead, StringReturned)
 {
     std::stringstream everything("\" asdf \\\"\\\\\\/\\b\\f\\n\\r\\t\\u0030 \"");
-    std::string result = Json::Read::String(everything);
+    std::string result = Json::Read::String<>(everything);
+    EXPECT_STREQ(" asdf \"\\/\b\f\n\r\t0 ", result.c_str());
+}
+
+TEST_HEADER(JsonInputRead, StringReturnedUnquoted)
+{
+    std::stringstream everything(" asdf \\\"\\\\\\/\\b\\f\\n\\r\\t\\u0030 ");
+    std::string result = Json::Read::String<false>(everything);
     EXPECT_STREQ(" asdf \"\\/\b\f\n\r\t0 ", result.c_str());
 }
 
@@ -1667,8 +1756,9 @@ struct VariousMaps
     std::map<int, Keyable> intObjMap;
     std::map<Keyable, int> objIntMap;
     std::map<Keyable, Keyable> objObjMap;
+    std::map<std::string, std::string> stringStringMap;
 
-    REFLECT(VariousMaps, intIntMap, intObjMap, objIntMap, objObjMap)
+    REFLECT(VariousMaps, intIntMap, intObjMap, objIntMap, objObjMap, stringStringMap)
 };
 
 TEST_HEADER(JsonInputRead, KeyValueObject)
@@ -1680,6 +1770,7 @@ TEST_HEADER(JsonInputRead, KeyValueObject)
     v.intObjMap = { {0, {0}} };
     v.objIntMap = { {{0}, 0} };
     v.objObjMap = { {{0}, {0}} };
+    v.stringStringMap = { {"", ""}};
     
     std::stringstream intIntMapStream("{\"key\":1,\"value\":2},");
     std::pair<int, int> value = { 0, 0 };
@@ -1708,6 +1799,13 @@ TEST_HEADER(JsonInputRead, KeyValueObject)
         objObjMapStream, Json::context, c, v, objObjElement);
     EXPECT_EQ(1, std::get<0>(objObjElement).a);
     EXPECT_EQ(2, std::get<1>(objObjElement).a);
+
+    std::stringstream stringStringMapStream("{\"key\":\"1\",\"value\":\"2\"},");
+    std::pair<std::string, std::string> stringStringValue;
+    Json::Read::KeyValueObject<VariousMaps::Class::stringStringMap_::Field, VariousMaps>(
+        stringStringMapStream, Json::context, c, v, stringStringValue);
+    EXPECT_STREQ(std::get<0>(stringStringValue).c_str(), "1");
+    EXPECT_STREQ(std::get<1>(stringStringValue).c_str(), "2");
 }
 
 TEST_HEADER(JsonInputRead, FieldPair)
@@ -1719,6 +1817,7 @@ TEST_HEADER(JsonInputRead, FieldPair)
     v.intObjMap = { {0, {0}} };
     v.objIntMap = { {{0}, 0} };
     v.objObjMap = { {{0}, {0}} };
+    v.stringStringMap = { {"", ""}};
 
     std::stringstream intIntFieldPairStream("\"1\":2");
     std::pair<int, int> value;
@@ -1733,6 +1832,13 @@ TEST_HEADER(JsonInputRead, FieldPair)
         intObjFieldPairStream, Json::context, c, v, intObjValue.first, intObjValue.second);
     EXPECT_EQ(1, std::get<0>(intObjValue));
     EXPECT_EQ(2, std::get<1>(intObjValue).a);
+
+    std::stringstream stringStringFieldPairStream("\"1\":\"2\"");
+    std::pair<std::string, std::string> stringStringValue;
+    Json::Read::FieldPair<VariousMaps::Class::stringStringMap_::Field, VariousMaps>(
+        stringStringFieldPairStream, Json::context, c, v, stringStringValue.first, stringStringValue.second);
+    EXPECT_STREQ(std::get<0>(stringStringValue).c_str(), "1");
+    EXPECT_STREQ(std::get<1>(stringStringValue).c_str(), "2");
 }
 
 TEST_HEADER(JsonInputRead, Iterable)

--- a/RareCppTest/JsonTest.cpp
+++ b/RareCppTest/JsonTest.cpp
@@ -1603,17 +1603,17 @@ TEST_HEADER(JsonOutputCustomizersTest, CustomizeNoSpecialization)
     CustomizeNoSpecialization noSpecialization;
 
     bool isSpecialized = Json::Output::Customize<CustomizeNoSpecialization, int, CustomizeNoSpecialization::Class::IndexOf::integer,
-        NoAnnotation, CustomizeNoSpecialization::Class::integer_::Field, Json::Statics::Included, true, 0, 0, Json::twoSpaces>
+        NoAnnotation, CustomizeNoSpecialization::Class::integer_::Field, Json::Statics::Included, true, 0, Json::twoSpaces>
         ::As(os, Json::context, noSpecialization, noSpecialization.integer);
     EXPECT_FALSE(isSpecialized);
 
     isSpecialized = Json::Output::Customize<CustomizeNoSpecialization, char, CustomizeNoSpecialization::Class::IndexOf::character,
-        NoAnnotation, CustomizeNoSpecialization::Class::character_::Field, Json::Statics::Included, true, 0, 0, Json::twoSpaces>
+        NoAnnotation, CustomizeNoSpecialization::Class::character_::Field, Json::Statics::Included, true, 0, Json::twoSpaces>
         ::As(os, Json::context, noSpecialization, noSpecialization.character);
     EXPECT_FALSE(isSpecialized);
 
     isSpecialized = Json::Output::HaveSpecialization<CustomizeNoSpecialization, int, CustomizeNoSpecialization::Class::IndexOf::integer,
-        NoAnnotation, CustomizeNoSpecialization::Class::integer_::Field, Json::Statics::Included, true, 0, 0, Json::twoSpaces>;
+        NoAnnotation, CustomizeNoSpecialization::Class::integer_::Field, Json::Statics::Included, true, 0, Json::twoSpaces>;
     EXPECT_FALSE(isSpecialized);
 }
 
@@ -1622,27 +1622,27 @@ TEST_HEADER(JsonOutputCustomizersTest, CustomizeFullySpecialized)
     CustomizeFullySpecialized fullySpecialized;
 
     bool isSpecialized = Json::Output::Customize<CustomizeFullySpecialized, int, CustomizeFullySpecialized::Class::IndexOf::firstField,
-        NoAnnotation, CustomizeFullySpecialized::Class::firstField_::Field, Json::Statics::Included, true, 0, 0, Json::twoSpaces>
+        NoAnnotation, CustomizeFullySpecialized::Class::firstField_::Field, Json::Statics::Included, true, 0, Json::twoSpaces>
         ::As(os, Json::context, fullySpecialized, fullySpecialized.firstField);
     EXPECT_TRUE(isSpecialized);
     isSpecialized = Json::Output::HaveSpecialization<CustomizeFullySpecialized, int, CustomizeFullySpecialized::Class::IndexOf::firstField,
-        NoAnnotation, CustomizeFullySpecialized::Class::firstField_::Field, Json::Statics::Included, true, 0, 0, Json::twoSpaces>;
+        NoAnnotation, CustomizeFullySpecialized::Class::firstField_::Field, Json::Statics::Included, true, 0, Json::twoSpaces>;
     EXPECT_TRUE(isSpecialized);
 
     isSpecialized = Json::Output::Customize<CustomizeFullySpecialized, int, CustomizeFullySpecialized::Class::IndexOf::secondField,
-        NoAnnotation, CustomizeFullySpecialized::Class::secondField_::Field, Json::Statics::Included, true, 0, 0, Json::twoSpaces>
+        NoAnnotation, CustomizeFullySpecialized::Class::secondField_::Field, Json::Statics::Included, true, 0, Json::twoSpaces>
         ::As(os, Json::context, fullySpecialized, fullySpecialized.secondField);
     EXPECT_TRUE(isSpecialized);
     isSpecialized = Json::Output::HaveSpecialization<CustomizeFullySpecialized, int, CustomizeFullySpecialized::Class::IndexOf::secondField,
-        NoAnnotation, CustomizeFullySpecialized::Class::secondField_::Field, Json::Statics::Included, true, 0, 0, Json::twoSpaces>;
+        NoAnnotation, CustomizeFullySpecialized::Class::secondField_::Field, Json::Statics::Included, true, 0, Json::twoSpaces>;
     EXPECT_TRUE(isSpecialized);
 
     isSpecialized = Json::Output::Customize<CustomizeFullySpecialized, char, CustomizeFullySpecialized::Class::IndexOf::unspecialized,
-        NoAnnotation, CustomizeFullySpecialized::Class::unspecialized_::Field, Json::Statics::Included, true, 0, 0, Json::twoSpaces>
+        NoAnnotation, CustomizeFullySpecialized::Class::unspecialized_::Field, Json::Statics::Included, true, 0, Json::twoSpaces>
         ::As(os, Json::context, fullySpecialized, fullySpecialized.unspecialized);
     EXPECT_FALSE(isSpecialized);
     isSpecialized = Json::Output::HaveSpecialization<CustomizeFullySpecialized, char, CustomizeFullySpecialized::Class::IndexOf::unspecialized,
-        NoAnnotation, CustomizeFullySpecialized::Class::unspecialized_::Field, Json::Statics::Included, true, 0, 0, Json::twoSpaces>;
+        NoAnnotation, CustomizeFullySpecialized::Class::unspecialized_::Field, Json::Statics::Included, true, 0, Json::twoSpaces>;
     EXPECT_FALSE(isSpecialized);
 }
 
@@ -1859,10 +1859,10 @@ TEST_HEADER(JsonOutputCustomizersTest, CustomizeTypeUnspecialized)
     ContainsUnspecialized containsUnspecialized;
 
     bool isSpecialized = Json::Output::CustomizeType<UnspecializedType, NoAnnotation, ContainsUnspecialized::Class::unspecializedType_::Field,
-        Json::Statics::Included, true, 0, 0, Json::twoSpaces>::As(os, Json::context, containsUnspecialized.unspecializedType);
+        Json::Statics::Included, true, 0, Json::twoSpaces>::As(os, Json::context, containsUnspecialized.unspecializedType);
     EXPECT_FALSE(isSpecialized);
     isSpecialized = Json::Output::HaveSpecialization<ContainsUnspecialized, UnspecializedType, ContainsUnspecialized::Class::IndexOf::unspecializedType, NoAnnotation, ContainsUnspecialized::Class::unspecializedType_::Field,
-        Json::Statics::Included, true, 0, 0, Json::twoSpaces>;
+        Json::Statics::Included, true, 0, Json::twoSpaces>;
     EXPECT_FALSE(isSpecialized);
 }
 
@@ -1871,10 +1871,10 @@ TEST_HEADER(JsonOutputCustomizersTest, CustomizeTypeFullySpecialized)
     ContainsFullySpecialized containsFullySpecialized;
 
     bool isSpecialized = Json::Output::CustomizeType<FullySpecializedType, NoAnnotation, ContainsFullySpecialized::Class::fullySpecializedType_::Field,
-        Json::Statics::Included, true, 0, 0, Json::twoSpaces>::As(os, Json::context, containsFullySpecialized.fullySpecializedType);
+        Json::Statics::Included, true, 0, Json::twoSpaces>::As(os, Json::context, containsFullySpecialized.fullySpecializedType);
     EXPECT_TRUE(isSpecialized);
     isSpecialized = Json::Output::HaveSpecialization<ContainsFullySpecialized, FullySpecializedType, ContainsFullySpecialized::Class::IndexOf::fullySpecializedType, NoAnnotation, ContainsFullySpecialized::Class::fullySpecializedType_::Field,
-        Json::Statics::Included, true, 0, 0, Json::twoSpaces>;
+        Json::Statics::Included, true, 0, Json::twoSpaces>;
     EXPECT_TRUE(isSpecialized);
 }
 
@@ -1971,7 +1971,7 @@ TEST_HEADER(JsonOutputStaticAffixTest, StaticArrayPrefix)
     EXPECT_STREQ("[ ", primitivePrettyPrint.str().c_str());
 
     TestStreamType nonPrimitivePrettyCompare;
-    nonPrimitivePrettyCompare << "[" << osEndl << Json::Indent<true, 3, Json::twoSpaces>;
+    nonPrimitivePrettyCompare << "[" << osEndl << Json::Indent<true, 4, Json::twoSpaces>;
     TestStreamType nonPrimitivePretty;
     nonPrimitivePretty << Json::ArrayPrefix<true, false, 3, Json::twoSpaces>;
     EXPECT_STREQ(nonPrimitivePrettyCompare.str().c_str(), nonPrimitivePretty.str().c_str());
@@ -2247,7 +2247,7 @@ TEST_HEADER(JsonOutputPutAffixTest, ArrayPrefix)
 
     TestStreamType prettyNonPrimitivesCompare;
     prettyNonPrimitivesCompare << "[" << osEndl;
-    Json::Put::Indent<true, Json::twoSpaces>(prettyNonPrimitivesCompare, 3);
+    Json::Put::Indent<true, Json::twoSpaces>(prettyNonPrimitivesCompare, 4);
 
     TestStreamType prettyNonPrimitives;
     Json::Put::ArrayPrefix<true, false, Json::twoSpaces>(prettyNonPrimitives, 3);
@@ -2555,88 +2555,88 @@ TEST_HEADER(JsonOutputPut, Customization)
     int objectPlaceholder;
     using Field = CustomizeNoSpecialization::Class::integer_::Field;
     CustomizeNoSpecialization customizeNoSpecialization;
-    bool customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, 3, Json::twoSpaces>(
+    bool customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, Json::twoSpaces>(
         os, Json::context, customizeNoSpecialization, objectPlaceholder);
     EXPECT_FALSE(customized);
 
     CustomizeFullySpecialized customizeFullySpecialized;
-    customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, 3, Json::twoSpaces>(
+    customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, Json::twoSpaces>(
         os, Json::context, customizeFullySpecialized, objectPlaceholder);
     EXPECT_TRUE(customized);
 
     Customize5ArgSpecialized customize5ArgSpecialized;
-    customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, 3, Json::twoSpaces>(
+    customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, Json::twoSpaces>(
         os, Json::context, customize5ArgSpecialized, objectPlaceholder);
     EXPECT_TRUE(customized);
 
     Customize4ArgSpecialized customize4ArgSpecialized;
-    customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, 3, Json::twoSpaces>(
+    customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, Json::twoSpaces>(
         os, Json::context, customize4ArgSpecialized, objectPlaceholder);
     EXPECT_TRUE(customized);
 
     Customize3ArgSpecialized customize3ArgSpecialized;
-    customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, 3, Json::twoSpaces>(
+    customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, Json::twoSpaces>(
         os, Json::context, customize3ArgSpecialized, objectPlaceholder);
     EXPECT_TRUE(customized);
 
     Customize2ArgSpecialized customize2ArgSpecialized;
-    customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, 3, Json::twoSpaces>(
+    customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, Json::twoSpaces>(
         os, Json::context, customize2ArgSpecialized, objectPlaceholder);
     EXPECT_TRUE(customized);
 
     Customize5ArgSpecialized_OpAnnotationsDefaulted customize5ArgSpecialized_opAnnotationsDefaulted;
-    customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, 3, Json::twoSpaces>(
+    customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, Json::twoSpaces>(
         os, Json::context, customize5ArgSpecialized_opAnnotationsDefaulted, objectPlaceholder);
     EXPECT_TRUE(customized);
 
     Customize5ArgSpecialized_FieldIndexDefaulted customize5ArgSpecialized_fieldIndexDefaulted;
-    customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, 3, Json::twoSpaces>(
+    customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, Json::twoSpaces>(
         os, Json::context, customize5ArgSpecialized_fieldIndexDefaulted, objectPlaceholder);
     EXPECT_TRUE(customized);
 
     Customize5ArgSpecialized_BothDefaulted customize5ArgSpecialized_bothDefaulted;
-    customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, 3, Json::twoSpaces>(
+    customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, Json::twoSpaces>(
         os, Json::context, customize5ArgSpecialized_bothDefaulted, objectPlaceholder);
     EXPECT_TRUE(customized);
 
     Customize4ArgSpecialized_FieldIndexDefaulted customize4ArgSpecialized_fieldIndexDefaulted;
-    customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, 3, Json::twoSpaces>(
+    customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, Json::twoSpaces>(
         os, Json::context, customize4ArgSpecialized_fieldIndexDefaulted, objectPlaceholder);
     EXPECT_TRUE(customized);
 
     UnspecializedType unspecializedType;
     ContainsUnspecialized containsUnspecialized;
-    customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, 3, Json::twoSpaces>(
+    customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, Json::twoSpaces>(
         os, Json::context, containsUnspecialized, unspecializedType);
     EXPECT_FALSE(customized);
 
     FullySpecializedType fullySpecializedType;
     ContainsFullySpecialized containsFullySpecialized;
-    customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, 3, Json::twoSpaces>(
+    customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, Json::twoSpaces>(
         os, Json::context, containsFullySpecialized, fullySpecializedType);
     EXPECT_TRUE(customized);
 
     ThreeArgSpecializedType threeArgSpecializedType;
     ContainsThreeArgSpecialized containsThreeArgSpecialized;
-    customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, 3, Json::twoSpaces>(
+    customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, Json::twoSpaces>(
         os, Json::context, containsThreeArgSpecialized, threeArgSpecializedType);
     EXPECT_TRUE(customized);
 
     TwoArgSpecializedType twoArgSpecializedType;
     ContainsTwoArgSpecialized containsTwoArgSpecialized;
-    customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, 3, Json::twoSpaces>(
+    customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, Json::twoSpaces>(
         os, Json::context, containsTwoArgSpecialized, twoArgSpecializedType);
     EXPECT_TRUE(customized);
 
     OneArgSpecializedType oneArgSpecializedType;
     ContainsOneArgSpecialized containsOneArgSpecialized;
-    customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, 3, Json::twoSpaces>(
+    customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, Json::twoSpaces>(
         os, Json::context, containsOneArgSpecialized, oneArgSpecializedType);
     EXPECT_TRUE(customized);
 
     ThreeArgSpecializedType_OpAnnotationsDefaulted threeArgSpecializedType_opAnnotationsDefaulted;
     ContainsThreeArgSpecializedType_OpAnnotationsDefaulted containsThreeArgSpecializedType_opAnnotationDefaulted;
-    customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, 3, Json::twoSpaces>(
+    customized = Json::Put::Customization<Notate, Field, Json::Statics::Included, true, 3, Json::twoSpaces>(
         os, Json::context, containsThreeArgSpecializedType_opAnnotationDefaulted, threeArgSpecializedType_opAnnotationsDefaulted);
     EXPECT_TRUE(customized);
 }
@@ -2709,46 +2709,46 @@ TEST_HEADER(JsonOutputPut, GenericValue)
         fieldClusterStream;
 
     Json::Bool boolean(true);
-    Json::Put::GenericValue<NoAnnotation, false, Json::twoSpaces, true>(booleanStream, Json::context, 0, 0, boolean);
+    Json::Put::GenericValue<NoAnnotation, false, Json::twoSpaces, true>(booleanStream, Json::context, 0, boolean);
     EXPECT_STREQ("true", booleanStream.str().c_str());
 
     Json::Number number("123.456");
-    Json::Put::GenericValue<NoAnnotation, false, Json::twoSpaces, true>(numberStream, Json::context, 0, 0, number);
+    Json::Put::GenericValue<NoAnnotation, false, Json::twoSpaces, true>(numberStream, Json::context, 0, number);
     EXPECT_STREQ("123.456", numberStream.str().c_str());
 
     Json::String str("asd\nf");
-    Json::Put::GenericValue<NoAnnotation, false, Json::twoSpaces, true>(strStream, Json::context, 0, 0, str);
+    Json::Put::GenericValue<NoAnnotation, false, Json::twoSpaces, true>(strStream, Json::context, 0, str);
     EXPECT_STREQ("\"asd\\nf\"", strStream.str().c_str());
 
     Json::Object obj;
     obj.put("astr", std::make_shared<Json::String>("asdf"));
     obj.put("null", nullptr);
     obj.put("number", std::make_shared<Json::Number>("1234"));
-    Json::Put::GenericValue<NoAnnotation, false, Json::twoSpaces, true>(objStream, Json::context, 0, 0, obj);
+    Json::Put::GenericValue<NoAnnotation, false, Json::twoSpaces, true>(objStream, Json::context, 0, obj);
     EXPECT_STREQ("{\"astr\":\"asdf\",\"null\":null,\"number\":1234}", objStream.str().c_str());
 
     Json::NullArray nullArray(3);
-    Json::Put::GenericValue<NoAnnotation, false, Json::twoSpaces, true>(nullArrayStream, Json::context, 0, 0, nullArray);
+    Json::Put::GenericValue<NoAnnotation, false, Json::twoSpaces, true>(nullArrayStream, Json::context, 0, nullArray);
     EXPECT_STREQ("[null,null,null]", nullArrayStream.str().c_str());
 
     Json::BoolArray boolArray;
     boolArray.boolArray().push_back(true);
     boolArray.boolArray().push_back(true);
     boolArray.boolArray().push_back(false);
-    Json::Put::GenericValue<NoAnnotation, false, Json::twoSpaces, true>(boolArrayStream, Json::context, 0, 0, boolArray);
+    Json::Put::GenericValue<NoAnnotation, false, Json::twoSpaces, true>(boolArrayStream, Json::context, 0, boolArray);
     EXPECT_STREQ("[true,true,false]", boolArrayStream.str().c_str());
 
     Json::NumberArray numberArray;
     numberArray.numberArray().push_back("2");
     numberArray.numberArray().push_back("1");
     numberArray.numberArray().push_back("0.5");
-    Json::Put::GenericValue<NoAnnotation, false, Json::twoSpaces, true>(numberArrayStream, Json::context, 0, 0, numberArray);
+    Json::Put::GenericValue<NoAnnotation, false, Json::twoSpaces, true>(numberArrayStream, Json::context, 0, numberArray);
     EXPECT_STREQ("[2,1,0.5]", numberArrayStream.str().c_str());
 
     Json::StringArray strArray;
     strArray.stringArray().push_back("as");
     strArray.stringArray().push_back("df");
-    Json::Put::GenericValue<NoAnnotation, false, Json::twoSpaces, true>(strArrayStream, Json::context, 0, 0, strArray);
+    Json::Put::GenericValue<NoAnnotation, false, Json::twoSpaces, true>(strArrayStream, Json::context, 0, strArray);
     EXPECT_STREQ("[\"as\",\"df\"]", strArrayStream.str().c_str());
 
     Json::ObjectArray objArray;
@@ -2757,19 +2757,19 @@ TEST_HEADER(JsonOutputPut, GenericValue)
     objElement.insert(std::pair("null", nullptr));
     objElement.insert(std::pair("number", std::make_shared<Json::Number>("1234")));
     objArray.objectArray().push_back(objElement);
-    Json::Put::GenericValue<NoAnnotation, false, Json::twoSpaces, true>(objArrayStream, Json::context, 0, 0, objArray);
+    Json::Put::GenericValue<NoAnnotation, false, Json::twoSpaces, true>(objArrayStream, Json::context, 0, objArray);
     EXPECT_STREQ("[{\"astr\":\"asdf\",\"null\":null,\"number\":1234}]", objArrayStream.str().c_str());
 
     Json::MixedArray mixedArray;
     mixedArray.mixedArray().push_back(std::make_shared<Json::Bool>(true));
     mixedArray.mixedArray().push_back(nullptr);
-    Json::Put::GenericValue<NoAnnotation, false, Json::twoSpaces, true>(mixedArrayStream, Json::context, 0, 0, mixedArray);
+    Json::Put::GenericValue<NoAnnotation, false, Json::twoSpaces, true>(mixedArrayStream, Json::context, 0, mixedArray);
     EXPECT_STREQ("[true,null]", mixedArrayStream.str().c_str());
 
     Json::FieldCluster fieldCluster;
     fieldCluster.put("astr", std::make_shared<Json::String>("asdf"));
     fieldCluster.put("number", std::make_shared<Json::Number>("1234"));
-    Json::Put::GenericValue<NoAnnotation, false, Json::twoSpaces, true>(fieldClusterStream, Json::context, 0, 0, fieldCluster);
+    Json::Put::GenericValue<NoAnnotation, false, Json::twoSpaces, true>(fieldClusterStream, Json::context, 0, fieldCluster);
     EXPECT_STREQ("\"astr\":\"asdf\",\"number\":1234", fieldClusterStream.str().c_str());
 }
 
@@ -2786,31 +2786,31 @@ TEST_HEADER(JsonOutputPut, GenericIterable)
     Json::Object obj;
     obj.put("astr", std::make_shared<Json::String>("asdf"));
     obj.put("number", std::make_shared<Json::Number>("1234"));
-    Json::Put::GenericIterable<NoAnnotation, false, Json::twoSpaces>(objStream, Json::context, 3, 3, obj);
+    Json::Put::GenericIterable<NoAnnotation, false, Json::twoSpaces>(objStream, Json::context, 3, obj);
     EXPECT_STREQ("{\"astr\":\"asdf\",\"number\":1234}", objStream.str().c_str());
 
     Json::NullArray nullArray(3);
-    Json::Put::GenericIterable<NoAnnotation, false, Json::twoSpaces>(nullArrayStream, Json::context, 3, 3, nullArray);
+    Json::Put::GenericIterable<NoAnnotation, false, Json::twoSpaces>(nullArrayStream, Json::context, 3, nullArray);
     EXPECT_STREQ("[null,null,null]", nullArrayStream.str().c_str());
 
     Json::BoolArray boolArray;
     boolArray.boolArray().push_back(true);
     boolArray.boolArray().push_back(true);
     boolArray.boolArray().push_back(false);
-    Json::Put::GenericIterable<NoAnnotation, false, Json::twoSpaces>(boolArrayStream, Json::context, 3, 3, boolArray);
+    Json::Put::GenericIterable<NoAnnotation, false, Json::twoSpaces>(boolArrayStream, Json::context, 3, boolArray);
     EXPECT_STREQ("[true,true,false]", boolArrayStream.str().c_str());
 
     Json::NumberArray numberArray;
     numberArray.numberArray().push_back("2");
     numberArray.numberArray().push_back("1");
     numberArray.numberArray().push_back("0.5");
-    Json::Put::GenericIterable<NoAnnotation, false, Json::twoSpaces>(numberArrayStream, Json::context, 3, 3, numberArray);
+    Json::Put::GenericIterable<NoAnnotation, false, Json::twoSpaces>(numberArrayStream, Json::context, 3, numberArray);
     EXPECT_STREQ("[2,1,0.5]", numberArrayStream.str().c_str());
 
     Json::StringArray stringArray;
     stringArray.stringArray().push_back("as");
     stringArray.stringArray().push_back("df");
-    Json::Put::GenericIterable<NoAnnotation, false, Json::twoSpaces>(strArrayStream, Json::context, 3, 3, stringArray);
+    Json::Put::GenericIterable<NoAnnotation, false, Json::twoSpaces>(strArrayStream, Json::context, 3, stringArray);
     EXPECT_STREQ("[\"as\",\"df\"]", strArrayStream.str().c_str());
 
     Json::ObjectArray objArray;
@@ -2818,13 +2818,13 @@ TEST_HEADER(JsonOutputPut, GenericIterable)
     objElement.insert(std::pair("astr", std::make_shared<Json::String>("asdf")));
     objElement.insert(std::pair("number", std::make_shared<Json::Number>("1234")));
     objArray.objectArray().push_back(objElement);
-    Json::Put::GenericIterable<NoAnnotation, false, Json::twoSpaces>(objArrayStream, Json::context, 3, 3, objArray);
+    Json::Put::GenericIterable<NoAnnotation, false, Json::twoSpaces>(objArrayStream, Json::context, 3, objArray);
     EXPECT_STREQ("[{\"astr\":\"asdf\",\"number\":1234}]", objArrayStream.str().c_str());
 
     Json::MixedArray mixedArray;
     mixedArray.mixedArray().push_back(std::make_shared<Json::Bool>(true));
     mixedArray.mixedArray().push_back(nullptr);
-    Json::Put::GenericIterable<NoAnnotation, false, Json::twoSpaces>(mixedArrayStream, Json::context, 3, 3, mixedArray);
+    Json::Put::GenericIterable<NoAnnotation, false, Json::twoSpaces>(mixedArrayStream, Json::context, 3, mixedArray);
     EXPECT_STREQ("[true,null]", mixedArrayStream.str().c_str());
 }
 
@@ -2876,70 +2876,70 @@ TEST_HEADER(JsonOutputPut, Value)
     CustomizeFullySpecialized customized;
     customized.firstField = 1337;
     Json::Put::Value<NoAnnotation, CustomizeFullySpecialized::Class::firstField_::Field,
-        Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, CustomizeFullySpecialized, true>
+        Json::Statics::Excluded, false, 0, Json::twoSpaces, CustomizeFullySpecialized, true>
         (customizedStream, Json::context, customized, customized.firstField);
     EXPECT_STREQ("\"Customized1337\"", customizedStream.str().c_str());
 
     int* nullPointer = nullptr;
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(nullPointerStream, Json::context, placeholderObj, nullPointer);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(nullPointerStream, Json::context, placeholderObj, nullPointer);
     EXPECT_STREQ("null", nullPointerStream.str().c_str());
 
     int anInt = 555;
     int* intPointer = &anInt;
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(intPointerStream, Json::context, placeholderObj, intPointer);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(intPointerStream, Json::context, placeholderObj, intPointer);
     EXPECT_STREQ("555", intPointerStream.str().c_str());
 
     anInt = 556;
     const int* constIntPointer = &anInt;
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(constIntPointerStream, Json::context, placeholderObj, constIntPointer);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(constIntPointerStream, Json::context, placeholderObj, constIntPointer);
     EXPECT_STREQ("556", constIntPointerStream.str().c_str());
     
     anInt = 557;
     int* const intConstPointer = &anInt;
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(intConstPointerStream, Json::context, placeholderObj, intConstPointer);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(intConstPointerStream, Json::context, placeholderObj, intConstPointer);
     EXPECT_STREQ("557", intConstPointerStream.str().c_str());
     
     anInt = 558;
     const int* const constIntConstPointer = &anInt;
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(constIntConstPointerStream, Json::context, placeholderObj, constIntConstPointer);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(constIntConstPointerStream, Json::context, placeholderObj, constIntConstPointer);
     EXPECT_STREQ("558", constIntConstPointerStream.str().c_str());
 
     Json::Number number("123.456");
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(genericNumberStream, Json::context, placeholderObj, number);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(genericNumberStream, Json::context, placeholderObj, number);
     EXPECT_STREQ("123.456", genericNumberStream.str().c_str());
 
     std::vector<int> intVector = { 1, 2, 3 };
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(intVectorStream, Json::context, placeholderObj, intVector);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(intVectorStream, Json::context, placeholderObj, intVector);
     EXPECT_STREQ("[1,2,3]", intVectorStream.str().c_str());
 
     std::map<int, int> intMap = { {1, 2}, {3, 4}, {5, 6} };
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(intMapStream, Json::context, placeholderObj, intMap);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(intMapStream, Json::context, placeholderObj, intMap);
     EXPECT_STREQ("{\"1\":2,\"3\":4,\"5\":6}", intMapStream.str().c_str());
 
     InstanceField rootObj;
     rootObj.a = 5;
-    Json::Put::Value<NoAnnotation, Fields::Field<InstanceField, void*, 0, NoAnnotation>, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(rootObjStream, Json::context, placeholderObj, rootObj);
+    Json::Put::Value<NoAnnotation, Fields::Field<InstanceField, void*, 0, NoAnnotation>, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(rootObjStream, Json::context, placeholderObj, rootObj);
     EXPECT_STREQ("{\"a\":5}", rootObjStream.str().c_str());
 
     InstanceField obj;
     obj.a = 6;
-    Json::Put::Value<NoAnnotation, Fields::Field<InstanceField, void*, 0, NoAnnotation>, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(reflectedObjStream, Json::context, placeholderObj, obj);
+    Json::Put::Value<NoAnnotation, Fields::Field<InstanceField, void*, 0, NoAnnotation>, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(reflectedObjStream, Json::context, placeholderObj, obj);
     EXPECT_STREQ("{\"a\":6}", reflectedObjStream.str().c_str());
 
     std::string str = "asdf";
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(strStream, Json::context, placeholderObj, str);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(strStream, Json::context, placeholderObj, str);
     EXPECT_STREQ("\"asdf\"", strStream.str().c_str());
 
     AnEnum enumInt = AnEnum::first;
-    Json::Put::Value<NoAnnotation, Fields::Field<AnEnum, void*, 0, Json::EnumIntType>, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(enumIntStream, Json::context, placeholderObj, enumInt);
+    Json::Put::Value<NoAnnotation, Fields::Field<AnEnum, void*, 0, Json::EnumIntType>, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(enumIntStream, Json::context, placeholderObj, enumInt);
     EXPECT_STREQ("0", enumIntStream.str().c_str());
 
     bool boolean = false;
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(booleanStream, Json::context, placeholderObj, boolean);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(booleanStream, Json::context, placeholderObj, boolean);
     EXPECT_STREQ("false", booleanStream.str().c_str());
 
     short shortInt = 22222;
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(shortIntStream, Json::context, placeholderObj, shortInt);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(shortIntStream, Json::context, placeholderObj, shortInt);
     EXPECT_STREQ("22222", shortIntStream.str().c_str());
 
     
@@ -2958,47 +2958,47 @@ TEST_HEADER(JsonOutputPut, Value)
     Keyable otherKey { 1 };
 
     std::tuple<> shouldBeNull;
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(emptyTupleStream, Json::context, placeholderObj, shouldBeNull);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(emptyTupleStream, Json::context, placeholderObj, shouldBeNull);
     EXPECT_STREQ("null", emptyTupleStream.str().c_str());
 
     std::tuple<int> shouldBeInt { 1337 };
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(intTupleStream, Json::context, placeholderObj, shouldBeInt);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(intTupleStream, Json::context, placeholderObj, shouldBeInt);
     EXPECT_STREQ("1337", intTupleStream.str().c_str());
 
     std::tuple<int, int> shouldBe2Array { 1, 2 };
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(intIntTupleStream, Json::context, placeholderObj, shouldBe2Array);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(intIntTupleStream, Json::context, placeholderObj, shouldBe2Array);
     EXPECT_STREQ("[1,2]", intIntTupleStream.str().c_str());
 
     std::tuple<int, int, int> shouldBe3Array { 1, 2, 3 };
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(intIntIntTupleStream, Json::context, placeholderObj, shouldBe3Array);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(intIntIntTupleStream, Json::context, placeholderObj, shouldBe3Array);
     EXPECT_STREQ("[1,2,3]", intIntIntTupleStream.str().c_str());
 
     std::pair<int, int> pair { 9000, 9001 };
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(intIntPairStream, Json::context, placeholderObj, pair);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(intIntPairStream, Json::context, placeholderObj, pair);
     EXPECT_STREQ("[9000,9001]", intIntPairStream.str().c_str());
 
     std::map<int, int> basicMap;
     basicMap.insert(std::make_pair(1, 2));
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(intIntMapStream, Json::context, placeholderObj, basicMap);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(intIntMapStream, Json::context, placeholderObj, basicMap);
     EXPECT_STREQ("{\"1\":2}", intIntMapStream.str().c_str());
 
     std::map<int, Keyable> primitiveObjMap;
     primitiveObjMap.insert(std::make_pair(1, keyable));
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(intKeyableMapStream, Json::context, placeholderObj, primitiveObjMap);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(intKeyableMapStream, Json::context, placeholderObj, primitiveObjMap);
     EXPECT_STREQ("{\"1\":{\"a\":0}}", intKeyableMapStream.str().c_str());
 
     std::map<Keyable, int> compKey;
     compKey.insert(std::make_pair(keyable, 1));
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(keyableIntMapStream, Json::context, placeholderObj, compKey);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(keyableIntMapStream, Json::context, placeholderObj, compKey);
     EXPECT_STREQ("[{\"key\":{\"a\":0},\"value\":1}]", keyableIntMapStream.str().c_str());
 
     std::map<Keyable, Keyable> compMap;
     compMap.insert(std::make_pair(keyable, otherKey));
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(keyableKeyableMapStream, Json::context, placeholderObj, compMap);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(keyableKeyableMapStream, Json::context, placeholderObj, compMap);
     EXPECT_STREQ("[{\"key\":{\"a\":0},\"value\":{\"a\":1}}]", keyableKeyableMapStream.str().c_str());
 
     std::tuple<std::tuple<int, int>, int> tup { {1, 2}, 3 };
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(intIntTupleIntTupleStream, Json::context, placeholderObj, tup);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(intIntTupleIntTupleStream, Json::context, placeholderObj, tup);
     EXPECT_STREQ("[[1,2],3]", intIntTupleIntTupleStream.str().c_str());
 }
 
@@ -3017,31 +3017,31 @@ TEST_HEADER(JsonOutputPut, Tuple)
     int placeholderObj = 0;
 
     std::tuple<> shouldBeNull;
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(emptyTupleStream, Json::context, placeholderObj, shouldBeNull);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(emptyTupleStream, Json::context, placeholderObj, shouldBeNull);
     EXPECT_STREQ("null", emptyTupleStream.str().c_str());
 
     std::tuple<int> shouldBeInt { 1337 };
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(intTupleStream, Json::context, placeholderObj, shouldBeInt);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(intTupleStream, Json::context, placeholderObj, shouldBeInt);
     EXPECT_STREQ("1337", intTupleStream.str().c_str());
 
     std::tuple<int, int> shouldBe2Array { 1, 2 };
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(intIntTupleStream, Json::context, placeholderObj, shouldBe2Array);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(intIntTupleStream, Json::context, placeholderObj, shouldBe2Array);
     EXPECT_STREQ("[1,2]", intIntTupleStream.str().c_str());
 
     std::tuple<int, int, int> shouldBe3Array { 1, 2, 3 };
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(intIntIntTupleStream, Json::context, placeholderObj, shouldBe3Array);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(intIntIntTupleStream, Json::context, placeholderObj, shouldBe3Array);
     EXPECT_STREQ("[1,2,3]", intIntIntTupleStream.str().c_str());
 
     std::tuple<std::tuple<int, int>, int> tup { {1, 2}, 3 };
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(intIntTupleIntTupleStream, Json::context, placeholderObj, tup);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(intIntTupleIntTupleStream, Json::context, placeholderObj, tup);
     EXPECT_STREQ("[[1,2],3]", intIntTupleIntTupleStream.str().c_str());
 
     std::tuple<int, std::vector<int>> intVectorTuple { 1, {2, 3, 4} };
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(intVectorTupleStream, Json::context, placeholderObj, intVectorTuple);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(intVectorTupleStream, Json::context, placeholderObj, intVectorTuple);
     EXPECT_STREQ("[1,[2,3,4]]", intVectorTupleStream.str().c_str());
 
     std::tuple<int, Keyable> intObjectTuple { 1, {2} };
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(intObjectTupleStream, Json::context, placeholderObj, intObjectTuple);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(intObjectTupleStream, Json::context, placeholderObj, intObjectTuple);
     EXPECT_STREQ("[1,{\"a\":2}]", intObjectTupleStream.str().c_str());
 }
 
@@ -3057,19 +3057,19 @@ TEST_HEADER(JsonOutputPut, Pair)
     int placeholderObj = 0;
     
     std::pair<int, int> intIntPair { 0, 1 };
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(intIntPairStream, Json::context, placeholderObj, intIntPair);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(intIntPairStream, Json::context, placeholderObj, intIntPair);
     EXPECT_STREQ("[0,1]", intIntPairStream.str().c_str());
 
     std::pair<int, std::vector<int>> intVectorPair { 0, {1, 2, 3} };
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(intVectorPairStream, Json::context, placeholderObj, intVectorPair);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(intVectorPairStream, Json::context, placeholderObj, intVectorPair);
     EXPECT_STREQ("[0,[1,2,3]]", intVectorPairStream.str().c_str());
 
     std::pair<int, Keyable> intObjectPair { 0, {1} };
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(intObjectPairStream, Json::context, placeholderObj, intObjectPair);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(intObjectPairStream, Json::context, placeholderObj, intObjectPair);
     EXPECT_STREQ("[0,{\"a\":1}]", intObjectPairStream.str().c_str());
 
     std::pair<int, std::pair<int, int>> intPairPair { 0, {1, 2} };
-    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(intPairPairStream, Json::context, placeholderObj, intPairPair);
+    Json::Put::Value<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(intPairPairStream, Json::context, placeholderObj, intPairPair);
     EXPECT_STREQ("[0,[1,2]]", intPairPairStream.str().c_str());
 }
 
@@ -3083,11 +3083,11 @@ TEST_HEADER(JsonOutputPut, KeyValueObject)
     int placeholderObj = 0;
 
     std::pair<int, int> intIntPair { 0, 1 };
-    Json::Put::KeyValueObject<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(intIntPairStream, Json::context, placeholderObj, intIntPair);
+    Json::Put::KeyValueObject<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(intIntPairStream, Json::context, placeholderObj, intIntPair);
     EXPECT_STREQ("{\"key\":0,\"value\":1}", intIntPairStream.str().c_str());
 
     std::pair<Keyable, Keyable> objObjPair { {0}, {1} };
-    Json::Put::KeyValueObject<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(objObjPairStream, Json::context, placeholderObj, objObjPair);
+    Json::Put::KeyValueObject<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(objObjPairStream, Json::context, placeholderObj, objObjPair);
     EXPECT_STREQ("{\"key\":{\"a\":0},\"value\":{\"a\":1}}", objObjPairStream.str().c_str());
 }
 
@@ -3101,7 +3101,7 @@ TEST_HEADER(JsonOutputPut, FieldPair)
     int placeholderObj = 0;
 
     std::pair<int, int> intIntPair { 0, 1 };
-    Json::Put::FieldPair<NoAnnotation, AField, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(intIntPairStream, Json::context, placeholderObj, intIntPair);
+    Json::Put::FieldPair<NoAnnotation, AField, Json::Statics::Excluded, false, 0, Json::twoSpaces, int, true>(intIntPairStream, Json::context, placeholderObj, intIntPair);
     EXPECT_STREQ("\"0\":1", intIntPairStream.str().c_str());
 }
 
@@ -3128,15 +3128,15 @@ TEST_HEADER(JsonOutputPut, Iterable)
     containsIterables.intQueue.push(3);
     containsIterables.intQueue.push(4);
 
-    Json::Put::Iterable<NoAnnotation, ContainsIterables::Class::intVector_::Field, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, ContainsIterables>(
+    Json::Put::Iterable<NoAnnotation, ContainsIterables::Class::intVector_::Field, Json::Statics::Excluded, false, 0, Json::twoSpaces, ContainsIterables>(
         intVectorStream, Json::context, containsIterables, containsIterables.intVector);
     EXPECT_STREQ("[1,2,3]", intVectorStream.str().c_str());
 
-    Json::Put::Iterable<NoAnnotation, ContainsIterables::Class::intQueue_::Field, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, ContainsIterables>(
+    Json::Put::Iterable<NoAnnotation, ContainsIterables::Class::intQueue_::Field, Json::Statics::Excluded, false, 0, Json::twoSpaces, ContainsIterables>(
         intQueueStream, Json::context, containsIterables, containsIterables.intQueue);
     EXPECT_STREQ("[2,3,4]", intQueueStream.str().c_str());
 
-    Json::Put::Iterable<NoAnnotation, ContainsIterables::Class::intArray_::Field, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, ContainsIterables>(
+    Json::Put::Iterable<NoAnnotation, ContainsIterables::Class::intArray_::Field, Json::Statics::Excluded, false, 0, Json::twoSpaces, ContainsIterables>(
         intArrayStream, Json::context, containsIterables, containsIterables.intArray);
     EXPECT_STREQ("[3,4,5]", intArrayStream.str().c_str());
 }

--- a/RareCppTest/JsonTest.h
+++ b/RareCppTest/JsonTest.h
@@ -25,9 +25,9 @@ struct CustomizeFullySpecialized
 };
 
 template <size_t FieldIndex, typename OpAnnotations, typename Field, Json::Statics statics,
-    bool PrettyPrint, size_t TotalParentIterables, size_t IndentLevel, const char* indent>
+    bool PrettyPrint, size_t IndentLevel, const char* indent>
 struct Json::Output::Customize<CustomizeFullySpecialized, int, FieldIndex, OpAnnotations, Field, statics,
-    PrettyPrint, TotalParentIterables, IndentLevel, indent>
+    PrettyPrint, IndentLevel, indent>
 {
     static bool As(Json::OutStreamType & output, Json::Context & context, const CustomizeFullySpecialized & object, const int & value)
     {
@@ -205,8 +205,8 @@ struct ContainsFullySpecialized
 };
 
 template <typename OpAnnotations, typename Field, Json::Statics statics,
-    bool PrettyPrint, size_t TotalParentIterables, size_t IndentLevel, const char* indent>
-struct Json::Output::CustomizeType<FullySpecializedType, OpAnnotations, Field, statics, PrettyPrint, TotalParentIterables, IndentLevel, indent>
+    bool PrettyPrint, size_t IndentLevel, const char* indent>
+struct Json::Output::CustomizeType<FullySpecializedType, OpAnnotations, Field, statics, PrettyPrint, IndentLevel, indent>
 {
     static bool As(Json::OutStreamType & output, Json::Context & context, const FullySpecializedType & value)
     {


### PR DESCRIPTION
- Allow for flexible base types types (the type of the value passed to Json::out, Json::pretty, and Json::in - e.g. map, vector, tuple) #69 
- Simplify Indentation/Pretty Print Logic (remove TotalParentIterables & IsRoot in favor of just IndentLevel)
- Enable reassigning Json::Value smart pointers upon inputting a different JSON type than it currently holds
- Fix for string keys in Json-Object compatible iterables #78