### PR TITLE
2.3.5 - Fix JSON Character-Like-Type Input

### DIFF
--- a/RareCppTest/json_input_test.cpp
+++ b/RareCppTest/json_input_test.cpp
@@ -2099,4 +2099,42 @@ TEST_HEADER(JsonInput, InProxyReflected)
     EXPECT_EQ(5, object.a);
 }
 
+struct CharacterLikeTypes
+{
+    char a = '\0';
+    signed char b = '\0';
+    unsigned char c = '\0';
+    std::int8_t d = 0;
+    std::uint8_t e = 0;
+
+    REFLECT(CharacterLikeTypes, a, b, c, d, e)
+};
+
+TEST_HEADER(JsonInput, InCharacterLikeTypes)
+{
+    std::stringstream smallInput("{\"a\":1,\"b\":2,\"c\":3,\"d\":4,\"e\":5}");
+    CharacterLikeTypes small {};
+    smallInput >> Json::in(small);
+    EXPECT_EQ(1, small.a);
+    EXPECT_EQ(2, small.b);
+    EXPECT_EQ(3, small.c);
+    EXPECT_EQ(4, small.d);
+    EXPECT_EQ(5, small.e);
+
+    std::stringstream largeInput("{\"a\":100,\"b\":101,\"c\":102,\"d\":103,\"e\":104}");
+    CharacterLikeTypes large {};
+    largeInput >> Json::in(large);
+    EXPECT_EQ(100, large.a);
+    EXPECT_EQ(101, large.b);
+    EXPECT_EQ(102, large.c);
+    EXPECT_EQ(103, large.d);
+    EXPECT_EQ(104, large.e);
+    
+    std::stringstream negativeInput("{\"b\":-101,\"d\":-102}");
+    CharacterLikeTypes negative {};
+    negativeInput >> Json::in(negative);
+    EXPECT_EQ(-101, negative.b);
+    EXPECT_EQ(-102, negative.d);
+}
+
 #endif

--- a/include/rarecpp/json.h
+++ b/include/rarecpp/json.h
@@ -3107,6 +3107,14 @@ namespace Json
                 if constexpr ( !std::is_const_v<EnumType> )
                     value = (RareTs::remove_pointer_t<Value>)temp;
             }
+
+            template <typename Value>
+            constexpr void charInt(std::istream & is, Value & value)
+            {
+                int temp {};
+                is >> temp;
+                value = Value(temp);
+            }
             
             inline std::string fieldName(std::istream & is, char & c)
             {
@@ -3428,6 +3436,8 @@ namespace Json
                     Read::enumInt<T>(is, value);
                 else if constexpr ( std::is_same_v<bool, std::remove_const_t<T>> )
                     Read::boolean<InArray>(is, c, value);
+                else if constexpr ( RareTs::is_char_v<RareTs::remove_cvref_t<T>> )
+                    Read::charInt<T>(is, value);
                 else if constexpr ( std::is_const_v<T> )
                     Consume::value<InArray>(is, c);
                 else

--- a/include/rarecpp/reflect.h
+++ b/include/rarecpp/reflect.h
@@ -1775,7 +1775,7 @@ i0,i1,i2,i3,i4,i5,i6,i7,i8,i9,j0,j1,j2,j3,j4,j5,j6,j7,j8,argAtArgMax,...) argAtA
             }
             template <size_t I, typename T> static constexpr auto & memberValue(T && t) {
                 using U = class_t<RareTs::remove_cvref_t<T>>;
-                return U::template F_<I>::template i(static_cast<forward_proxy_t<typename U::B_, T>>(t));
+                return U::template F_<I>::i(static_cast<forward_proxy_t<typename U::B_, T>>(t));
             }
 
             template <typename T, size_t ... Is> using member_types = std::tuple<typename class_t<T>::template F_<Is>::type...>;
@@ -2253,7 +2253,7 @@ i0,i1,i2,i3,i4,i5,i6,i7,i8,i9,j0,j1,j2,j3,j4,j5,j6,j7,j8,argAtArgMax,...) argAtA
                             constexpr size_t index = RareTs::index_of_v<MemberOf, T>;
                             if constexpr ( index < std::tuple_size_v<RareTs::remove_cvref_t<T>> )
                             {
-                                return ArgumentBuilder<Arguments>::template invokeInstance(std::get<index>(std::forward<T>(t)),
+                                return ArgumentBuilder<Arguments>::invokeInstance(std::get<index>(std::forward<T>(t)),
                                     pointer, std::forward<ArgBuilder>(argBuilder));
                             }
                             else

--- a/include/rarecpp/reflect.h
+++ b/include/rarecpp/reflect.h
@@ -254,6 +254,12 @@ i0,i1,i2,i3,i4,i5,i6,i7,i8,i9,j0,j1,j2,j3,j4,j5,j6,j7,j8,argAtArgMax,...) argAtA
         template <typename TypeIfVoid> struct replace_void<void, TypeIfVoid> { using type = TypeIfVoid; };
         template <typename T, typename TypeIfVoid> using replace_void_t = typename replace_void<T, TypeIfVoid>::type;
 
+        template <typename T> struct is_char : std::false_type {};
+        template <> struct is_char<char> : std::true_type {};
+        template <> struct is_char<signed char> : std::true_type {};
+        template <> struct is_char<unsigned char> : std::true_type {};
+        template <typename T> inline constexpr bool is_char_v = is_char<T>::value;
+
         template <typename T> struct promote_char { using type = T; };
         template <typename T> struct promote_char<const T> { using type = std::add_const_t<typename promote_char<T>::type>; };
         template <> struct promote_char<char> { using type = int; };


### PR DESCRIPTION
Before this fix for character-like-type JSON inputs a single character was being read then a separator was expected, this means an exception was always triggered for multi-character numbers (e.g. trying to input 120 for std::int8_t or such); after this fix an integer is read for the character like types (char, signed char, unsigned char, std::int8_t, std::uint8_t) and placed into the target (character-like) type.