### PR TITLE
feature/json optionals

### DIFF
--- a/RareCppTest/extended_type_support_test.cpp
+++ b/RareCppTest/extended_type_support_test.cpp
@@ -4,10 +4,12 @@
 #include <cstddef>
 #include <deque>
 #include <forward_list>
+#include <functional>
 #include <limits>
 #include <list>
 #include <map>
 #include <memory>
+#include <optional>
 #include <queue>
 #include <set>
 #include <stack>
@@ -436,6 +438,27 @@ TEST(RareTsTest, IsAdaptor)
     EXPECT_TRUE(is_adaptor_v<const std::stack<int>>);
     EXPECT_TRUE(is_adaptor_v<const std::queue<int>>);
     EXPECT_TRUE(is_adaptor_v<const std::priority_queue<int>>);
+}
+
+TEST(RareTsTest, IsOptional)
+{
+    EXPECT_FALSE(is_optional_v<int>);
+    EXPECT_FALSE(is_optional_v<int*>);
+    EXPECT_FALSE(is_optional_v<std::reference_wrapper<int>>);
+    EXPECT_FALSE(is_optional_v<std::vector<int>>);
+    EXPECT_FALSE(is_optional_v<std::unique_ptr<int>>);
+    EXPECT_TRUE(is_optional_v<std::optional<int>>);
+    EXPECT_TRUE(is_optional_v<std::optional<int*>>);
+    EXPECT_TRUE(is_optional_v<std::optional<std::vector<int>>>);
+
+    EXPECT_FALSE(is_optional_v<const int>);
+    EXPECT_FALSE(is_optional_v<const int*>);
+    EXPECT_FALSE(is_optional_v<const std::reference_wrapper<int>>);
+    EXPECT_FALSE(is_optional_v<const std::vector<int>>);
+    EXPECT_FALSE(is_optional_v<const std::unique_ptr<int>>);
+    EXPECT_TRUE(is_optional_v<const std::optional<int>>);
+    EXPECT_TRUE(is_optional_v<const std::optional<int*>>);
+    EXPECT_TRUE(is_optional_v<const std::optional<std::vector<int>>>);
 }
 
 TEST(RareTsTest, IsPair)

--- a/RareCppTest/json_input_test.cpp
+++ b/RareCppTest/json_input_test.cpp
@@ -2248,4 +2248,42 @@ TEST_HEADER(JsonInput, InCharacterLikeTypes)
     EXPECT_EQ(-102, negative.d);
 }
 
+struct VariousArrays
+{
+    int a[3] {};
+    int b[2][3] {};
+    int c[2][3][1] {};
+    std::array<int, 2> d {};
+
+    REFLECT(VariousArrays, a, b, c, d)
+};
+
+TEST_HEADER(JsonInput, InVariousArrays)
+{
+    std::stringstream input("{\"a\":[1,2,3],\"b\":[[4,5,6],[7,8,9]],\"c\":[[[4],[5],[6]],[[7],[8],[9]]],\"d\":[4,5]}");
+    VariousArrays read {};
+    input >> Json::in(read);
+    
+    EXPECT_EQ(1, read.a[0]);
+    EXPECT_EQ(2, read.a[1]);
+    EXPECT_EQ(3, read.a[2]);
+    
+    EXPECT_EQ(4, read.b[0][0]);
+    EXPECT_EQ(5, read.b[0][1]);
+    EXPECT_EQ(6, read.b[0][2]);
+    EXPECT_EQ(7, read.b[1][0]);
+    EXPECT_EQ(8, read.b[1][1]);
+    EXPECT_EQ(9, read.b[1][2]);
+    
+    EXPECT_EQ(4, read.c[0][0][0]);
+    EXPECT_EQ(5, read.c[0][1][0]);
+    EXPECT_EQ(6, read.c[0][2][0]);
+    EXPECT_EQ(7, read.c[1][0][0]);
+    EXPECT_EQ(8, read.c[1][1][0]);
+    EXPECT_EQ(9, read.c[1][2][0]);
+    
+    EXPECT_EQ(4, read.d[0]);
+    EXPECT_EQ(5, read.d[1]);
+}
+
 #endif

--- a/RareCppTest/json_input_test.cpp
+++ b/RareCppTest/json_input_test.cpp
@@ -2,6 +2,7 @@
 #include "json_input_test.h"
 #include <gtest/gtest.h>
 #include <iostream>
+#include <optional>
 #include <regex>
 #endif
 #ifdef GET_RUNJSONINPUTTESTSRC_CPP
@@ -2284,6 +2285,36 @@ TEST_HEADER(JsonInput, InVariousArrays)
     
     EXPECT_EQ(4, read.d[0]);
     EXPECT_EQ(5, read.d[1]);
+}
+
+struct InOptObj
+{
+    int a;
+
+    REFLECT(InOptObj, a)
+};
+
+struct InOptional
+{
+    std::optional<int> a = std::nullopt;
+    std::optional<InOptObj> b = std::nullopt;
+
+    REFLECT(InOptional, a, b)
+};
+
+TEST_HEADER(JsonInput, InOptionals)
+{
+    std::stringstream nullOptInput("{\"a\":null,\"b\":null}");
+    InOptional inNullOpt {};
+    nullOptInput >> Json::in(inNullOpt);
+    EXPECT_FALSE(inNullOpt.a);
+    EXPECT_FALSE(inNullOpt.b);
+
+    std::stringstream valueOptInput("{\"a\":1,\"b\":{\"a\":2}}");
+    InOptional inValueOpt {};
+    valueOptInput >> Json::in(inValueOpt);
+    EXPECT_EQ(1, *(inValueOpt.a));
+    EXPECT_EQ(2, inValueOpt.b->a);
 }
 
 #endif

--- a/RareCppTest/json_test.cpp
+++ b/RareCppTest/json_test.cpp
@@ -3051,37 +3051,44 @@ struct ContainsIterables
 {
     std::vector<int> intVector;
     int intArray[3];
+    std::array<int, 2> stlArray;
     std::queue<int> intQueue;
 
-    REFLECT(ContainsIterables, intVector, intQueue, intArray)
+    REFLECT(ContainsIterables, intVector, intArray, stlArray, intQueue)
 };
 
 TEST_HEADER(JsonOutputPut, Iterable)
 {
     TestStreamType intVectorStream,
         intQueueStream,
-        intArrayStream;
+        intArrayStream,
+        stlIntArrayStream;
 
     ContainsIterables containsIterables = {
         { 1, 2, 3 },
         { 3, 4, 5 },
+        { 4, 5 },
         {}
     };
     containsIterables.intQueue.push(2);
     containsIterables.intQueue.push(3);
     containsIterables.intQueue.push(4);
 
-    Json::Put::iterable<NoNote, Reflect<ContainsIterables>::MemberType::intVector, Json::Statics::Excluded, false, 0, Json::twoSpaces, ContainsIterables>(
+    Json::Put::iterable<NoNote, Reflect<ContainsIterables>::MemberType::intVector, Json::Statics::Excluded, false, 0, Json::twoSpaces>(
         intVectorStream, Json::defaultContext, containsIterables, containsIterables.intVector);
     EXPECT_STREQ("[1,2,3]", intVectorStream.str().c_str());
 
-    Json::Put::iterable<NoNote, Reflect<ContainsIterables>::MemberType::intQueue, Json::Statics::Excluded, false, 0, Json::twoSpaces, ContainsIterables>(
+    Json::Put::iterable<NoNote, Reflect<ContainsIterables>::MemberType::intQueue, Json::Statics::Excluded, false, 0, Json::twoSpaces>(
         intQueueStream, Json::defaultContext, containsIterables, containsIterables.intQueue);
     EXPECT_STREQ("[2,3,4]", intQueueStream.str().c_str());
 
-    Json::Put::iterable<NoNote, Reflect<ContainsIterables>::MemberType::intArray, Json::Statics::Excluded, false, 0, Json::twoSpaces, ContainsIterables>(
+    Json::Put::iterable<NoNote, Reflect<ContainsIterables>::MemberType::intArray, Json::Statics::Excluded, false, 0, Json::twoSpaces>(
         intArrayStream, Json::defaultContext, containsIterables, containsIterables.intArray);
     EXPECT_STREQ("[3,4,5]", intArrayStream.str().c_str());
+
+    Json::Put::iterable<NoNote, Reflect<ContainsIterables>::MemberType::stlArray, Json::Statics::Excluded, false, 0, Json::twoSpaces>(
+        stlIntArrayStream, Json::defaultContext, containsIterables, containsIterables.stlArray);
+    EXPECT_STREQ("[4,5]", stlIntArrayStream.str().c_str());
 }
 
 struct RegularFields
@@ -3301,6 +3308,16 @@ TEST_HEADER(JsonOutputTest, JsonOutputReflectedObject)
     EXPECT_STREQ("{\"integer\":4,\"str\":\"aString\",\"nestedObj\":{\"bool\":false,\"ray\":[1,2,3]}}", objStream.str().c_str());
 }
 
+struct SomeArrays
+{
+    int a[3] {1, 2, 3};
+    int b[2][3] {{4, 5, 6}, {7, 8, 9}};
+    int c[2][3][1] {{{4}, {5}, {6}}, {{7}, {8}, {9}}};
+    std::array<int, 2> d {4, 5};
+
+    REFLECT(SomeArrays, a, b, c, d)
+};
+
 TEST_HEADER(JsonOutputTest, JsonOut)
 {
     NestedObj nestedObj = { false, { 1, 2, 3 } };
@@ -3313,6 +3330,10 @@ TEST_HEADER(JsonOutputTest, JsonOut)
     TestStreamType finalObjStream;
     finalObjStream << Json::out(anObject);
     EXPECT_STREQ("{\"integer\":4,\"str\":\"aString\",\"nestedObj\":{\"bool\":false,\"ray\":[1,2,3]}}", finalObjStream.str().c_str());
+
+    TestStreamType arrayStream;
+    arrayStream << Json::out(SomeArrays{});
+    EXPECT_STREQ("{\"a\":[1,2,3],\"b\":[[4,5,6],[7,8,9]],\"c\":[[[4],[5],[6]],[[7],[8],[9]]],\"d\":[4,5]}", arrayStream.str().c_str());
 }
 
 TEST_HEADER(JsonOutputTest, OutProxyReflected)

--- a/RareCppTest/json_test.cpp
+++ b/RareCppTest/json_test.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <list>
 #include <memory>
+#include <optional>
 #include <queue>
 #include <regex>
 #include <stack>
@@ -1385,6 +1386,7 @@ TEST_HEADER(JsonIdentifiersTest, IsNonPrimitive)
     EXPECT_FALSE(Json::is_non_primitive_v<char**>);
     EXPECT_FALSE(Json::is_non_primitive_v<char&>);
     EXPECT_FALSE(Json::is_non_primitive_v<char&&>);
+    EXPECT_FALSE(Json::is_non_primitive_v<std::optional<char>>);
     EXPECT_FALSE(Json::is_non_primitive_v<std::unique_ptr<char>>);
     EXPECT_FALSE(Json::is_non_primitive_v<std::shared_ptr<char>>);
     EXPECT_FALSE(Json::is_non_primitive_v<int>);
@@ -1392,6 +1394,7 @@ TEST_HEADER(JsonIdentifiersTest, IsNonPrimitive)
     EXPECT_FALSE(Json::is_non_primitive_v<int**>);
     EXPECT_FALSE(Json::is_non_primitive_v<int&>);
     EXPECT_FALSE(Json::is_non_primitive_v<int&&>);
+    EXPECT_FALSE(Json::is_non_primitive_v<std::optional<int>>);
     EXPECT_FALSE(Json::is_non_primitive_v<std::unique_ptr<int>>);
     EXPECT_FALSE(Json::is_non_primitive_v<std::shared_ptr<int>>);
     EXPECT_FALSE(Json::is_non_primitive_v<std::string>);
@@ -1441,6 +1444,7 @@ TEST_HEADER(JsonIdentifiersTest, IsNonPrimitive)
     EXPECT_FALSE(Json::is_non_primitive_v<const char**>);
     EXPECT_FALSE(Json::is_non_primitive_v<const char&>);
     EXPECT_FALSE(Json::is_non_primitive_v<const char&&>);
+    EXPECT_FALSE(Json::is_non_primitive_v<const std::optional<char>>);
     EXPECT_FALSE(Json::is_non_primitive_v<const std::unique_ptr<char>>);
     EXPECT_FALSE(Json::is_non_primitive_v<const std::shared_ptr<char>>);
     EXPECT_FALSE(Json::is_non_primitive_v<const int>);
@@ -1448,6 +1452,7 @@ TEST_HEADER(JsonIdentifiersTest, IsNonPrimitive)
     EXPECT_FALSE(Json::is_non_primitive_v<const int**>);
     EXPECT_FALSE(Json::is_non_primitive_v<const int&>);
     EXPECT_FALSE(Json::is_non_primitive_v<const int&&>);
+    EXPECT_FALSE(Json::is_non_primitive_v<const std::optional<int>>);
     EXPECT_FALSE(Json::is_non_primitive_v<const std::unique_ptr<int>>);
     EXPECT_FALSE(Json::is_non_primitive_v<const std::shared_ptr<int>>);
     EXPECT_FALSE(Json::is_non_primitive_v<const std::string>);
@@ -3306,6 +3311,34 @@ TEST_HEADER(JsonOutputTest, JsonOutputReflectedObject)
     reflectedObj.put(objStream);
 
     EXPECT_STREQ("{\"integer\":4,\"str\":\"aString\",\"nestedObj\":{\"bool\":false,\"ray\":[1,2,3]}}", objStream.str().c_str());
+}
+
+struct OptObj
+{
+    int a;
+
+    REFLECT(OptObj, a)
+};
+
+struct Optional
+{
+    std::optional<int> a = std::nullopt;
+    std::optional<OptObj> b = std::nullopt;
+
+    REFLECT(Optional, a, b)
+};
+
+TEST_HEADER(JsonOutputTest, JsonOutOpt)
+{
+    Optional nullOpt {};
+    TestStreamType nullOptStream {};
+    nullOptStream << Json::out(nullOpt);
+    EXPECT_STREQ("{\"a\":null,\"b\":null}", nullOptStream.str().c_str());
+
+    Optional valueOpt { 1, OptObj{2} };
+    TestStreamType valueOptStream {};
+    valueOptStream << Json::out(valueOpt);
+    EXPECT_STREQ("{\"a\":1,\"b\":{\"a\":2}}", valueOptStream.str().c_str());
 }
 
 struct SomeArrays

--- a/RareCppTest/reflection_test.cpp
+++ b/RareCppTest/reflection_test.cpp
@@ -1,5 +1,6 @@
 #include <rarecpp/reflect.h>
 #include <gtest/gtest.h>
+#include <array>
 #include <cstddef>
 #include <map>
 #include <stack>
@@ -304,6 +305,8 @@ TEST(ReflectionTest, IsAggregateReflected)
     EXPECT_FALSE(is_aggregate_reflected<UnownedObj1>::value);
     EXPECT_FALSE(is_aggregate_reflected<UnownedObj2>::value);
     EXPECT_FALSE(is_aggregate_reflected<OwnedObj>::value);
+    bool isStdArrayAggregate = is_aggregate_reflected<std::array<int, 2>>::value;
+    EXPECT_FALSE(isStdArrayAggregate);
 
     EXPECT_FALSE(is_aggregate_reflected_v<does_not_have_reflected_class>);
     EXPECT_FALSE(is_aggregate_reflected_v<does_have_reflected_class>);
@@ -321,6 +324,8 @@ TEST(ReflectionTest, IsAggregateReflected)
     EXPECT_FALSE(is_aggregate_reflected_v<UnownedObj1>);
     EXPECT_FALSE(is_aggregate_reflected_v<UnownedObj2>);
     EXPECT_FALSE(is_aggregate_reflected_v<OwnedObj>);
+    isStdArrayAggregate = is_aggregate_reflected_v<std::array<int, 2>>;
+    EXPECT_FALSE(isStdArrayAggregate);
 }
 #endif
 

--- a/include/rarecpp/reflect.h
+++ b/include/rarecpp/reflect.h
@@ -340,6 +340,10 @@ i0,i1,i2,i3,i4,i5,i6,i7,i8,i9,j0,j1,j2,j3,j4,j5,j6,j7,j8,argAtArgMax,...) argAtA
         template <typename T> struct is_adaptor<first_of_t<T, typename T::container_type>> : std::true_type {};
         template <typename T> inline constexpr bool is_adaptor_v = is_adaptor<T>::value;
 
+        template <typename ... Ts> struct is_optional { static constexpr bool value = false; };
+        template <typename T> struct is_optional<first_of_t<T, typename T::value_type, decltype(*T{}), decltype(T{}.has_value())>> : std::true_type {};
+        template <typename T> inline constexpr bool is_optional_v = is_optional<T>::value;
+
         template <typename T> struct is_pair { static constexpr bool value = false; };
         template <typename L, typename R> struct is_pair<std::pair<L, R>> { static constexpr bool value = true; };
         template <typename L, typename R> struct is_pair<const std::pair<L, R>> { static constexpr bool value = true; };

--- a/include/rarecpp/reflect.h
+++ b/include/rarecpp/reflect.h
@@ -1608,7 +1608,7 @@ i0,i1,i2,i3,i4,i5,i6,i7,i8,i9,j0,j1,j2,j3,j4,j5,j6,j7,j8,argAtArgMax,...) argAtA
 
         #ifndef RARE_NO_CPP_20
         template <typename T, typename = void> struct is_aggregate_reflected : std::bool_constant<
-            std::is_aggregate_v<T> && !std::is_array_v<T> && !is_in_class_reflected_v<T> && !is_proxied_v<T> && !is_private_reflected_v<T>> {};
+            std::is_aggregate_v<T> && !RareTs::is_static_array_v<T> && !is_in_class_reflected_v<T> && !is_proxied_v<T> && !is_private_reflected_v<T>> {};
         template <typename T> inline constexpr bool is_aggregate_reflected_v = is_aggregate_reflected<T>::value;
         #else
         template <typename T, typename = void> struct is_aggregate_reflected : std::false_type {};
@@ -1733,7 +1733,7 @@ i0,i1,i2,i3,i4,i5,i6,i7,i8,i9,j0,j1,j2,j3,j4,j5,j6,j7,j8,argAtArgMax,...) argAtA
             template <class T, class=void> struct clazz {
                 template <class U, class=void> struct last { using type = void; };
                 #ifndef RARE_NO_CPP_20
-                template <class U> struct last<U, std::enable_if_t<std::is_aggregate_v<U> && !std::is_array_v<U>>> { using type = typename RareTs::AggregateClass<U>; };
+                template <class U> struct last<U, std::enable_if_t<std::is_aggregate_v<U> && !RareTs::is_static_array_v<U>>> { using type = typename RareTs::AggregateClass<U>; };
                 #endif
                 using type = typename last<T>::type;
             };


### PR DESCRIPTION
- Add std::optional support to JSON, with very similar behavior to std::unique_ptr
- Fix for std::array being treated as a reflected aggregate object (causes unexpected errors and is inconsistent across compilers)
- Fix JSON output for multidimensional arrays (which was using the dimension of the outermost array rather than the current array being printed)
- Add JSON unit tests for std::array, multi-dimensional arrays, and std::optional