### PR TITLE
Experimental/data history

### DIFF
--- a/RareCppTest/edit_test.cpp
+++ b/RareCppTest/edit_test.cpp
@@ -501,10 +501,10 @@ namespace EditorCumulative
         Bar bar;
         std::vector<Bar> barVec {}; NOTE(barVec, IndexSize<std::uint16_t>{})
         int intRay[5] {};
+        int mdIntRay[2][3] {};
         std::vector<Trig> trigs {}; NOTE(trigs, IndexSize<std::uint16_t>{})
-        
-        
-        REFLECT_NOTED(CumulativeTest, a, b, c, bar, barVec, intRay, trigs)
+
+        REFLECT_NOTED(CumulativeTest, a, b, c, bar, barVec, intRay, mdIntRay, trigs)
     };
 
     struct TracedCumulativeTest : Tracked<CumulativeTest, TracedCumulativeTest>
@@ -532,6 +532,7 @@ namespace EditorCumulative
             edit->intRay[2] = 5;
             edit->intRay.select({1, 2, 4});
             edit->intRay.selection() = 6;
+            edit->mdIntRay[1][2] = 23;
             edit->trigs.append(EditorCumulative::CumulativeTest::Trig{});
             edit->trigs.append(EditorCumulative::CumulativeTest::Trig{});
             edit->trigs[0].conditions[3].type = uint8_t(12);
@@ -562,7 +563,7 @@ namespace EditorCumulative
         endState << Json::out(*myObj);
         EXPECT_STREQ(endState.str().c_str(), "{\"a\":12,\"b\":\"qwerty\",\"c\":[5,6,7],\"bar\":{\"integer\":1,\"decimal\":2.2,\"ints\":[]},"
             "\"barVec\":[{\"integer\":1,\"decimal\":2.2,\"ints\":[3,4,8,9,10]},{\"integer\":3,\"decimal\":4.4,\"ints\":[3,4,5,8,9,10]},"
-            "{\"integer\":0,\"decimal\":0,\"ints\":[]}],\"intRay\":[0,6,6,0,6],\"trigs\":["
+            "{\"integer\":0,\"decimal\":0,\"ints\":[]}],\"intRay\":[0,6,6,0,6],\"mdIntRay\":[[0,0,0],[0,0,23]],\"trigs\":["
             "{\"conditions\":[{\"type\":11},{\"type\":0},{\"type\":0},{\"type\":12}]},"
             "{\"conditions\":[{\"type\":11},{\"type\":0},{\"type\":0},{\"type\":0}]}]}");
     }

--- a/include/rarecpp/editor.h
+++ b/include/rarecpp/editor.h
@@ -1,3 +1,4 @@
+// MIT License, Copyright (c) 2025 Justin F https://github.com/TheNitesWhoSay/RareCpp/blob/master/LICENSE
 #ifndef EDITOR_H
 #define EDITOR_H
 #include <algorithm>

--- a/include/rarecpp/editor.h
+++ b/include/rarecpp/editor.h
@@ -1022,13 +1022,13 @@ namespace RareEdit
         using path = std::tuple<std::tuple_element_t<Is, Pathway>..., PathMember<I>>;
         using member_type = typename RareTs::Member<T, I>::type;
         if constexpr ( RareTs::is_static_array_v<member_type> )
-            return decltype(editArray<Edit, default_index_type, RootData, member_type, Keys, Path>()){};
+            return decltype(editArray<Edit, default_index_type, RootData, member_type, Keys, path>()){};
         else if constexpr ( RareTs::is_specialization_v<member_type, std::vector> ) // Vector
-            return decltype(editVector<Edit, default_index_type, RootData, member_type, Keys, Path>()){};
+            return decltype(editVector<Edit, default_index_type, RootData, member_type, Keys, path>()){};
         else if constexpr ( RareTs::is_macro_reflected_v<member_type> ) // Reflected object
-            return std::type_identity<edit_members<Edit, default_index_type, RootData, member_type, Keys, Path>>{};
+            return std::type_identity<edit_members<Edit, default_index_type, RootData, member_type, Keys, path>>{};
         else // Primitive
-            return std::type_identity<EditPrimitive<Edit, default_index_type, RootData, member_type, Keys, Path>>{};
+            return std::type_identity<EditPrimitive<Edit, default_index_type, RootData, member_type, Keys, path>>{};
     }
 
     template <typename T> struct is_selection_leaf_member {

--- a/include/rarecpp/editor.h
+++ b/include/rarecpp/editor.h
@@ -7237,9 +7237,9 @@ namespace RareEdit
                         using element_type = RareTs::element_type_t<std::remove_cvref_t<U>>;
                         constexpr bool isLeaf = !RareTs::is_reflected_v<element_type> && std::is_void_v<RareTs::element_type_t<element_type>>;
                         if constexpr ( isLeaf )
-                            printEventOp<element_type, Member>(offset, Op(value));
+                            printEventOp<element_type, Member>(offset, Op(op));
                         else
-                            printEvent<std::remove_cvref_t<decltype(std::declval<U>()[0])>, Member>(offset, op, std::make_index_sequence<reflectedMemberCount<U>()>());
+                            printEvent<std::remove_cvref_t<decltype(std::declval<U>()[0])>, Member>(offset, op, std::make_index_sequence<reflectedMemberCount<std::remove_cvref_t<decltype(std::declval<U>()[0])>>()>());
                     }
                     break;
                 case PathOp::LeafSelBranch:
@@ -7247,7 +7247,7 @@ namespace RareEdit
                     {
                         std::cout << "[{sel}]";
                         using element_type = RareTs::element_type_t<std::remove_cvref_t<U>>;
-                        printEventOp<element_type, Member>(offset, Op(value));
+                        printEventOp<element_type, Member>(offset, Op(op));
                     }
                     break;
                 case PathOp::Branch:
@@ -7261,7 +7261,7 @@ namespace RareEdit
                             index = editable.template readIndex<base_index_type>(offset);
 
                         std::cout << '[' << static_cast<std::size_t>(index) << ']';
-                        printEvent<std::remove_cvref_t<decltype(std::declval<U>()[0])>, Member>(offset, op, std::make_index_sequence<reflectedMemberCount<U>()>());
+                        printEvent<std::remove_cvref_t<decltype(std::declval<U>()[0])>, Member>(offset, op, std::make_index_sequence<reflectedMemberCount<std::remove_cvref_t<decltype(std::declval<U>()[0])>>()>());
                     }
                     else if constexpr ( RareTs::is_macro_reflected_v<U> ) // Branch to field
                     {
@@ -7282,7 +7282,7 @@ namespace RareEdit
                 break;
                 case PathOp::LeafBranch:
                 {
-                    if constexpr ( RareTs::is_static_array_v<U> ) // Op on index
+                    if constexpr ( RareTs::is_static_array_v<U> || RareTs::is_specialization_v<U, std::vector> ) // Op on index
                     {
                         base_index_type index {};
                         if constexpr ( std::is_same_v<uint6_t, base_index_type> )
@@ -7291,7 +7291,7 @@ namespace RareEdit
                             index = editable.template readIndex<base_index_type>(offset);
 
                         std::cout << "[" << static_cast<std::size_t>(index) << "]";
-                        printEventOp<RareTs::element_type_t<std::remove_cvref_t<U>>, Member>(offset, Op(value));
+                        printEventOp<RareTs::element_type_t<std::remove_cvref_t<U>>, Member>(offset, Op(op));
                     }
                     else if constexpr ( RareTs::is_reflected_v<U> ) // Op on field
                     {
@@ -7299,7 +7299,7 @@ namespace RareEdit
                         (void)(
                             (Is == memberIndex ? (
                                 std::cout << "." << RareTs::Member<U, Is>::name,
-                                printEventOp<typename RareTs::Member<U, Is>::type, RareTs::Member<U, Is>>(offset, Op(value)),
+                                printEventOp<typename RareTs::Member<U, Is>::type, RareTs::Member<U, Is>>(offset, Op(op)),
                                 true) : true) && ...
                         );
                         /*RareTs::Members<U>::at(memberIndex, [&](auto member) {

--- a/include/rarecpp/json.h
+++ b/include/rarecpp/json.h
@@ -1,4 +1,4 @@
-// MIT License, Copyright (c) 2019-2023 Justin F https://github.com/TheNitesWhoSay/RareCpp/blob/master/LICENSE
+// MIT License, Copyright (c) 2019-2025 Justin F https://github.com/TheNitesWhoSay/RareCpp/blob/master/LICENSE
 #ifndef JSON_H
 #define JSON_H
 #ifndef REFLECT_H // This check, while normally redundant to have here, helps the file work on godbolt

--- a/include/rarecpp/json.h
+++ b/include/rarecpp/json.h
@@ -17,6 +17,7 @@
 #include <limits>
 #include <map>
 #include <memory>
+#include <optional>
 #include <ostream>
 #include <sstream>
 #include <string>
@@ -1668,9 +1669,9 @@ namespace Json
                     D d = RareMapper::map<D>(value);
                     Put::value<Annotations, MockMember<D>, statics, PrettyPrint, IndentLevel, Indent, Object, IsFirst>(os, context, obj, d);
                 }
-                else if constexpr ( RareTs::is_pointable_v<T> )
+                else if constexpr ( RareTs::is_specialization_v<T, std::optional> || RareTs::is_pointable_v<T> )
                 {
-                    if ( value == nullptr )
+                    if ( !value )
                         os << "null";
                     else
                     {

--- a/include/rarecpp/reflect.h
+++ b/include/rarecpp/reflect.h
@@ -1,4 +1,4 @@
-// MIT License, Copyright (c) 2019-2023 Justin F https://github.com/TheNitesWhoSay/RareCpp/blob/master/LICENSE
+// MIT License, Copyright (c) 2019-2025 Justin F https://github.com/TheNitesWhoSay/RareCpp/blob/master/LICENSE
 #ifndef REFLECT_H
 #define REFLECT_H
 #include <array>

--- a/include/rarecpp/reflect.h
+++ b/include/rarecpp/reflect.h
@@ -1732,7 +1732,7 @@ i0,i1,i2,i3,i4,i5,i6,i7,i8,i9,j0,j1,j2,j3,j4,j5,j6,j7,j8,argAtArgMax,...) argAtA
             template <class T, class=void> struct clazz {
                 template <class U, class=void> struct last { using type = void; };
                 #ifndef RARE_NO_CPP_20
-                template <class U> struct last<U, std::enable_if_t<std::is_aggregate_v<U> && !std::is_array_v<U>>> { using type = typename RareTs::AggregateClass<U>; };
+                template <class U> struct last<U, std::enable_if_t<std::is_aggregate_v<U> && !RareTs::is_static_array_v<U>>> { using type = typename RareTs::AggregateClass<U>; };
                 #endif
                 using type = typename last<T>::type;
             };

--- a/include/rarecpp/reflect.h
+++ b/include/rarecpp/reflect.h
@@ -1602,6 +1602,9 @@ i0,i1,i2,i3,i4,i5,i6,i7,i8,i9,j0,j1,j2,j3,j4,j5,j6,j7,j8,argAtArgMax,...) argAtA
         template <typename T> struct is_private_reflected<T, std::void_t<decltype(GlobalClass<T>::I_::N_)>> : std::true_type {};
         template <typename T> inline constexpr bool is_private_reflected_v = is_private_reflected<T>::value;
 
+        template <typename T> struct is_macro_reflected : std::bool_constant<is_in_class_reflected_v<T> || is_proxied_v<T> || is_private_reflected_v<T>> {};
+        template <typename T> inline constexpr bool is_macro_reflected_v = is_macro_reflected<T>::value;
+
         #ifndef RARE_NO_CPP_20
         template <typename T, typename = void> struct is_aggregate_reflected : std::bool_constant<
             std::is_aggregate_v<T> && !std::is_array_v<T> && !is_in_class_reflected_v<T> && !is_proxied_v<T> && !is_private_reflected_v<T>> {};

--- a/include/rarecpp/string_buffer.h
+++ b/include/rarecpp/string_buffer.h
@@ -1,4 +1,4 @@
-// MIT License, Copyright (c) 2019-2023 Justin F https://github.com/TheNitesWhoSay/RareCpp/blob/master/LICENSE
+// MIT License, Copyright (c) 2019-2025 Justin F https://github.com/TheNitesWhoSay/RareCpp/blob/master/LICENSE
 #ifndef STRINGBUFFER_H
 #define STRINGBUFFER_H
 #include <array>


### PR DESCRIPTION
- Add is_macro_reflected trait
- Add editor support for 2d arrays
- Better editor support for std::array, smaller arrays implicitly using uint6_t
- Refactor IndexTypeTuple/indexes to be called "keys"
- Include a license line on editor, update license lines on other headers
- Greatly improved editor compile times for undo, redo, and print by removing several hotpath lambdas in favor of folds, replacing std::tuple with variadic templates or type_tags where possible, reducing instantiations where possible