### PR TITLE
Clang 19 fixes.

### DIFF
--- a/RareCppTest/reflection_test.cpp
+++ b/RareCppTest/reflection_test.cpp
@@ -1334,17 +1334,27 @@ class MyObjAccess {
 
 TEST(ReflectionTest, AccessModifier)
 {
+
+#ifdef __clang__
+#if __clang_major__ >= 19
+#define CLANG19ANDUP
+#endif
+#endif
+
     constexpr RareTs::AccessMod publicReference = // Not supported if _MSC_VER < 1932 and defaults to private
 #ifdef RARE_DISABLE_REF_ACCESS
         RareTs::AccessMod::Private;
 #else
         RareTs::AccessMod::Public;
 #endif
+
+#ifndef CLANG19ANDUP
     constexpr RareTs::AccessMod protectedReference = // If _MSC_VER < 1932 then not supported/defaults to private
 #ifdef RARE_DISABLE_REF_ACCESS
         RareTs::AccessMod::Private;
 #else
         RareTs::AccessMod::Protected;
+#endif
 #endif
 
     RareTs::AccessMod accessModifier = RareTs::access_modifier_v<MyObjAccess, 0>;
@@ -1362,6 +1372,37 @@ TEST(ReflectionTest, AccessModifier)
     accessModifier = RareTs::access_modifier_v<MyObjAccess, 6>; // Overloads are not currently supported and default to private
     EXPECT_EQ(RareTs::AccessMod::Private, accessModifier);
 
+#ifdef CLANG19ANDUP
+    accessModifier = RareTs::access_modifier_v<MyObjAccess, 7>;
+    EXPECT_EQ(RareTs::AccessMod::Public, accessModifier);
+    accessModifier = RareTs::access_modifier_v<MyObjAccess, 8>; // If _MSC_VER < 1932 then not supported/defaults to private
+    EXPECT_EQ(RareTs::AccessMod::Public, accessModifier);
+    accessModifier = RareTs::access_modifier_v<MyObjAccess, 9>;
+    EXPECT_EQ(RareTs::AccessMod::Public, accessModifier);
+    accessModifier = RareTs::access_modifier_v<MyObjAccess, 10>;
+    EXPECT_EQ(RareTs::AccessMod::Public, accessModifier);
+    accessModifier = RareTs::access_modifier_v<MyObjAccess, 11>;
+    EXPECT_EQ(RareTs::AccessMod::Public, accessModifier);
+    accessModifier = RareTs::access_modifier_v<MyObjAccess, 12>;
+    EXPECT_EQ(RareTs::AccessMod::Public, accessModifier);
+    accessModifier = RareTs::access_modifier_v<MyObjAccess, 13>; // Overloads are not currently supported and default to private
+    EXPECT_EQ(RareTs::AccessMod::Private, accessModifier);
+
+    accessModifier = RareTs::access_modifier_v<MyObjAccess, 14>;
+    EXPECT_EQ(RareTs::AccessMod::Public, accessModifier);
+    accessModifier = RareTs::access_modifier_v<MyObjAccess, 15>;
+    EXPECT_EQ(RareTs::AccessMod::Public, accessModifier);
+    accessModifier = RareTs::access_modifier_v<MyObjAccess, 16>;
+    EXPECT_EQ(RareTs::AccessMod::Public, accessModifier);
+    accessModifier = RareTs::access_modifier_v<MyObjAccess, 17>;
+    EXPECT_EQ(RareTs::AccessMod::Public, accessModifier);
+    accessModifier = RareTs::access_modifier_v<MyObjAccess, 18>;
+    EXPECT_EQ(RareTs::AccessMod::Public, accessModifier);
+    accessModifier = RareTs::access_modifier_v<MyObjAccess, 19>;
+    EXPECT_EQ(RareTs::AccessMod::Public, accessModifier);
+    accessModifier = RareTs::access_modifier_v<MyObjAccess, 20>;
+    EXPECT_EQ(RareTs::AccessMod::Private, accessModifier);
+#else
     accessModifier = RareTs::access_modifier_v<MyObjAccess, 7>;
     EXPECT_EQ(RareTs::AccessMod::Protected, accessModifier);
     accessModifier = RareTs::access_modifier_v<MyObjAccess, 8>; // If _MSC_VER < 1932 then not supported/defaults to private
@@ -1390,5 +1431,60 @@ TEST(ReflectionTest, AccessModifier)
     accessModifier = RareTs::access_modifier_v<MyObjAccess, 19>;
     EXPECT_EQ(RareTs::AccessMod::Private, accessModifier);
     accessModifier = RareTs::access_modifier_v<MyObjAccess, 20>;
+    EXPECT_EQ(RareTs::AccessMod::Private, accessModifier);
+#endif
+}
+
+
+class MyObjAccessPrivRefl {
+    public:
+        int aData = 0;
+        static int aStaticData;
+        void aFunc();
+        static void aStaticFunc();
+    protected:
+        int bData = 0;
+        static int bStaticData;
+        void bFunc();
+        static void bStaticFunc();
+    private:
+        int cData = 0;
+        static int cStaticData;
+        void cFunc();
+        static void cStaticFunc();
+};
+
+REFLECT_PRIVATE(MyObjAccessPrivRefl,
+    aData, aStaticData, aFunc, aStaticFunc,
+    bData, bStaticData, bFunc, bStaticFunc,
+    cData, cStaticData, cFunc, cStaticFunc)
+
+TEST(ReflectionTest, PrivateReflectedAccessModifier)
+{
+    RareTs::AccessMod accessModifier = RareTs::access_modifier_v<MyObjAccessPrivRefl, 0>;
+    EXPECT_EQ(RareTs::AccessMod::Public, accessModifier);
+    accessModifier = RareTs::access_modifier_v<MyObjAccessPrivRefl, 1>;
+    EXPECT_EQ(RareTs::AccessMod::Public, accessModifier);
+    accessModifier = RareTs::access_modifier_v<MyObjAccessPrivRefl, 2>;
+    EXPECT_EQ(RareTs::AccessMod::Public, accessModifier);
+    accessModifier = RareTs::access_modifier_v<MyObjAccessPrivRefl, 3>;
+    EXPECT_EQ(RareTs::AccessMod::Public, accessModifier);
+
+    accessModifier = RareTs::access_modifier_v<MyObjAccessPrivRefl, 4>;
+    EXPECT_EQ(RareTs::AccessMod::Protected, accessModifier);
+    accessModifier = RareTs::access_modifier_v<MyObjAccessPrivRefl, 5>;
+    EXPECT_EQ(RareTs::AccessMod::Protected, accessModifier);
+    accessModifier = RareTs::access_modifier_v<MyObjAccessPrivRefl, 6>;
+    EXPECT_EQ(RareTs::AccessMod::Protected, accessModifier);
+    accessModifier = RareTs::access_modifier_v<MyObjAccessPrivRefl, 7>;
+    EXPECT_EQ(RareTs::AccessMod::Protected, accessModifier);
+
+    accessModifier = RareTs::access_modifier_v<MyObjAccessPrivRefl, 8>;
+    EXPECT_EQ(RareTs::AccessMod::Private, accessModifier);
+    accessModifier = RareTs::access_modifier_v<MyObjAccessPrivRefl, 9>;
+    EXPECT_EQ(RareTs::AccessMod::Private, accessModifier);
+    accessModifier = RareTs::access_modifier_v<MyObjAccessPrivRefl, 10>;
+    EXPECT_EQ(RareTs::AccessMod::Private, accessModifier);
+    accessModifier = RareTs::access_modifier_v<MyObjAccessPrivRefl, 11>;
     EXPECT_EQ(RareTs::AccessMod::Private, accessModifier);
 }

--- a/include/rarecpp/reflect.h
+++ b/include/rarecpp/reflect.h
@@ -1632,8 +1632,8 @@ i0,i1,i2,i3,i4,i5,i6,i7,i8,i9,j0,j1,j2,j3,j4,j5,j6,j7,j8,argAtArgMax,...) argAtA
                 template <template<class...> class Op, class... Args>
                 struct op_exists<std::void_t<Op<Args...>>, Op, Args...> { static constexpr bool value = true; };
 
-                template <typename U = typename decltype(classType(RareTs::type_tag<RareTs::Proxy<RareTs::remove_cvref_t<T>>>{}))::template A_<MemberIndex, T>>
-                static constexpr bool value = !op_exists<void, U::template t, T>::value && !op_exists<void, U::template p, T>::value;
+                template <typename U = typename decltype(classType(RareTs::type_tag<RareTs::Proxy<RareTs::remove_cvref_t<T>>>{}))::template A_<MemberIndex, T, T>>
+                static constexpr bool value = !op_exists<void, U::template t, U>::value && !op_exists<void, U::template p, U>::value;
             };
         }
         #endif
@@ -1917,7 +1917,7 @@ i0,i1,i2,i3,i4,i5,i6,i7,i8,i9,j0,j1,j2,j3,j4,j5,j6,j7,j8,argAtArgMax,...) argAtA
 
             #ifdef __clang__
             // Overloads (and references on MSVC < 1932 / Visual Studios <= 2019) are unsupported/always private
-            template <typename T, size_t MemberIndex, typename U = typename Class::class_t<T>::template A_<MemberIndex>>
+            template <typename T, size_t MemberIndex, typename U = typename Class::class_t<T>::template A_<MemberIndex, T>>
             struct access_modifier
             {
                 static constexpr AccessMod value = [](){
@@ -1925,7 +1925,7 @@ i0,i1,i2,i3,i4,i5,i6,i7,i8,i9,j0,j1,j2,j3,j4,j5,j6,j7,j8,argAtArgMax,...) argAtA
                         return Class::MemberAnnotationsType<T, MemberIndex>::template getNote<AccessMod>();
                     else if constexpr ( RareTs::op_exists<void, U::template t, T>::value || RareTs::op_exists<void, U::template p, T>::value )
                         return AccessMod::Public;
-                    else if constexpr ( detail::is_private_member<T, MemberIndex>::template value<> ) // this actually detects not protected/defaults to true
+                    else if constexpr ( detail::is_private_member<std::remove_cvref_t<T>, MemberIndex>::template value<> ) // this actually detects not protected/defaults to true
                         return AccessMod::Private;
                     else
                         return AccessMod::Protected;
@@ -2619,8 +2619,8 @@ namespace RareTs { constexpr inline RareTs::GlobalClass<x> classType(RareTs::typ
 #endif
 
 #ifdef __clang__
-#define RARE_ACCESS_HEADER template <size_t, class=void> struct A_;
-#define RARE_ACCESS_MEMBER(x) template <class U_> struct A_<I_::x, U_> { \
+#define RARE_ACCESS_HEADER template <size_t, class=void, class...> struct A_;
+#define RARE_ACCESS_MEMBER(x) template <class U_, class ... Us_> struct A_<I_::x, U_, Us_...> : Us_... { \
     template <class T_> using t = decltype(T_::x); \
     template <class T_> using p = decltype(&T_::x); };
 #else


### PR DESCRIPTION
- Fix for protected member detection in clang 19 for REFLECT_PRIVATE classes
- Unit tests added for REFLECT_PRIVATE class access modifier detection
- Unit test updated for REFLECT class access modifier detection so it no longer fails for clang 19 and up (where detecting access modifiers seems impossible).