### PR TITLE
Experimental/data history

### DIFF
--- a/RareCpp/experimental/tracking.cpp
+++ b/RareCpp/experimental/tracking.cpp
@@ -20,14 +20,15 @@ struct Actor
     REFLECT(Actor, xc, yc, name)
 };
 
-NOTE(MyObj, IndexSize<std::uint32_t>{})
+NOTE(MyObj, IndexSize<std::uint32_t>)
 struct MyObj
 {
     int intRay[5] {};
     std::vector<int> ints {};
+    Actor actor {};
     std::vector<Actor> actors {};
 
-    REFLECT_NOTED(MyObj, ints, intRay, actors)
+    REFLECT_NOTED(MyObj, ints, intRay, actor, actors)
 };
 
 struct TracedObj : Tracked<MyObj, TracedObj>
@@ -45,6 +46,7 @@ struct TracedObj : Tracked<MyObj, TracedObj>
         auto edit = createAction();
         edit->intRay[2] = 5;
         edit->ints = std::vector{2, 3, 4};
+        edit->actor = Actor{.xc = 77, .yc = 88, .name = "jj"};
         edit->actors.append(Actor{});
         edit->actors.append(Actor{});
         edit->actors[1].xc = 12;

--- a/RareCpp/experimental/tracking.cpp
+++ b/RareCpp/experimental/tracking.cpp
@@ -18,6 +18,8 @@ struct Item
     REFLECT(Item, hitCount)
 };
 
+struct ActorLink { std::string label {}; };
+
 struct Actor
 {
     int xc = 0;
@@ -33,6 +35,7 @@ struct MyObj
 {
     std::vector<int> ints {};
     Actor actor {};
+    NOTE(actors, AttachData<ActorLink>)
     std::vector<Actor> actors {};
 
     REFLECT_NOTED(MyObj, ints, actor, actors)
@@ -84,6 +87,9 @@ struct TracedObj : Tracked<MyObj, TracedObj>
         edit->actors.select(0);
         edit->actors.moveSelectionsDown();
         //edit->actors.removeSelection();
+
+        auto & attachedData = view.actors.attachedData();
+        std::cout << RareTs::toStr<decltype(attachedData)>() << '\n';
     }
 
     void afterAction(std::size_t actionIndex)

--- a/RareCpp/experimental/tracking.cpp
+++ b/RareCpp/experimental/tracking.cpp
@@ -86,6 +86,27 @@ struct TracedObj : Tracked<MyObj, TracedObj>
         //edit->actors.removeSelection();
     }
 
+    void afterAction(std::size_t actionIndex)
+    {
+        auto hist = Tracked::renderChangeHistory();
+        auto & action = hist[actionIndex];
+        std::cout << "New Action[" << actionIndex << "](";
+        switch ( action.actionStatus )
+        {
+        case RareEdit::ActionStatus::Undoable: std::cout << "Undoable"; break;
+        case RareEdit::ActionStatus::ElidedRedo: if ( action.elisionCount > 0 ) std::cout << "ElideLast:" << action.elisionCount; else std::cout << "ElidedRedo"; break;
+        case RareEdit::ActionStatus::Redoable: std::cout << "Redoable"; break;
+        }
+        std::cout << ")\n";
+
+        auto & changeEvents = hist[actionIndex].changeEvents;
+        for ( std::size_t j=0; j<changeEvents.size(); ++j )
+        {
+            auto & changeEvent = changeEvents[j];
+            std::cout << "  " << changeEvent.summary << '\n';
+        }
+    }
+
     ActorElem getActorElem(std::size_t i) {
         return ActorElem(this, view.actors[i]);
     }
@@ -145,12 +166,14 @@ void dataHistory()
     std::cout << Json::out(*myObj);
     
     std::cout << "\n\ntestElemOp:\n";
-    auto actor = myObj.getActorElem(1);
-    actor.act();
-    auto item = actor.getItemElem(0);
-    item.hit();
-    actor.act();
-    item.hit();
+    {
+        auto actor = myObj.getActorElem(1);
+        actor.act();
+        auto item = actor.getItemElem(0);
+        item.hit();
+        actor.act();
+        item.hit();
+    }
     std::cout << Json::out(*myObj);
 
     std::cout << "\n\ntestUndo:\n";
@@ -161,7 +184,7 @@ void dataHistory()
     myObj.redoAction();
     std::cout << Json::out(*myObj) << "\n\n";
 
-    myObj.printChangeHistory();
+    myObj.printChangeHistory(std::cout);
 }
 
 }

--- a/RareCpp/experimental/tracking.cpp
+++ b/RareCpp/experimental/tracking.cpp
@@ -181,10 +181,15 @@ void dataHistory()
     myObj.undoAction();
     std::cout << Json::out(*myObj);
 
+    std::cout << "\n\ntestDo:\n";
+    myObj.doSomething();
+    std::cout << Json::out(*myObj);
+
     std::cout << "\n\ntestRedo:\n";
     myObj.redoAction();
-    std::cout << Json::out(*myObj) << "\n\n";
+    std::cout << Json::out(*myObj);
 
+    std::cout << "\n\n";
     myObj.printChangeHistory(std::cout);
 }
 

--- a/RareCpp/experimental/tracking.cpp
+++ b/RareCpp/experimental/tracking.cpp
@@ -18,8 +18,6 @@ struct Item
     REFLECT(Item, hitCount)
 };
 
-struct ActorLink { std::string label {}; };
-
 struct Actor
 {
     int xc = 0;
@@ -35,7 +33,6 @@ struct MyObj
 {
     std::vector<int> ints {};
     Actor actor {};
-    NOTE(actors, AttachData<ActorLink>)
     std::vector<Actor> actors {};
 
     REFLECT_NOTED(MyObj, ints, actor, actors)
@@ -87,9 +84,6 @@ struct TracedObj : Tracked<MyObj, TracedObj>
         edit->actors.select(0);
         edit->actors.moveSelectionsDown();
         //edit->actors.removeSelection();
-
-        auto & attachedData = view.actors.attachedData();
-        std::cout << RareTs::toStr<decltype(attachedData)>() << '\n';
     }
 
     void afterAction(std::size_t actionIndex)

--- a/RareCpp/experimental/tracking.cpp
+++ b/RareCpp/experimental/tracking.cpp
@@ -99,6 +99,7 @@ struct TracedObj : Tracked<MyObj, TracedObj>
         std::cout << "New Action[" << actionIndex << "](";
         switch ( action.actionStatus )
         {
+        case RareEdit::ActionStatus::Unknown: std::cout << "Unknown"; break;
         case RareEdit::ActionStatus::Undoable: std::cout << "Undoable"; break;
         case RareEdit::ActionStatus::ElidedRedo: if ( action.elisionCount > 0 ) std::cout << "ElideLast:" << action.elisionCount; else std::cout << "ElidedRedo"; break;
         case RareEdit::ActionStatus::Redoable: std::cout << "Redoable"; break;

--- a/RareCpp/experimental/tracking.cpp
+++ b/RareCpp/experimental/tracking.cpp
@@ -24,11 +24,13 @@ NOTE(MyObj, IndexSize<std::uint32_t>)
 struct MyObj
 {
     int intRay[5] {};
+    int int2Ray[2][3] {};
+    int int3Ray[2][3][4] {};
     std::vector<int> ints {};
     Actor actor {};
     std::vector<Actor> actors {};
 
-    REFLECT_NOTED(MyObj, ints, intRay, actor, actors)
+    REFLECT_NOTED(MyObj, ints, intRay, int2Ray, int3Ray, actor, actors)
 };
 
 struct TracedObj : Tracked<MyObj, TracedObj>
@@ -38,13 +40,18 @@ struct TracedObj : Tracked<MyObj, TracedObj>
     void setup()
     {
         auto edit = createAction();
+        edit->intRay[2] = 5;
+        edit->int2Ray[1][1] = 6;
+        edit->int3Ray[1][1][2] = 7;
         edit->ints.append(std::vector{0, 1, 2, 3, 4, 5, 6, 7, 8});
     }
 
     void doSomething()
     {
         auto edit = createAction();
-        edit->intRay[2] = 5;
+        edit->intRay.reset();
+        edit->int2Ray.reset();
+        edit->int3Ray.reset();
         edit->ints = std::vector{2, 3, 4};
         edit->actor = Actor{.xc = 77, .yc = 88, .name = "jj"};
         edit->actors.append(Actor{});

--- a/RareCpp/main.cpp
+++ b/RareCpp/main.cpp
@@ -107,9 +107,11 @@ void openMenu()
 int main()
 {
     // Set to whatever function you want called on startup (reset to &none when finished)
-    auto specificCall = &none;
+    auto specificCall = &experimental::dataHistory;
 
     specificCall();
-    openMenu();
+    std::cin.clear();
+    std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+    //openMenu();
     return 0;
 }

--- a/RareCpp/main.cpp
+++ b/RareCpp/main.cpp
@@ -107,11 +107,11 @@ void openMenu()
 int main()
 {
     // Set to whatever function you want called on startup (reset to &none when finished)
-    auto specificCall = &experimental::dataHistory;
+    auto specificCall = &none;
 
     specificCall();
-    std::cin.clear();
-    std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
-    //openMenu();
+    //std::cin.clear();
+    //std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+    openMenu();
     return 0;
 }

--- a/RareCppTest/CMakeLists.txt
+++ b/RareCppTest/CMakeLists.txt
@@ -11,6 +11,7 @@ set(Sources
   edit_test.cpp
   editor_notifications_test.cpp
   extended_type_support_test.cpp
+  flat_mdspan_test.cpp
   member_test.cpp
   generic_macro_test.cpp
   inherit_test.cpp

--- a/RareCppTest/CMakeLists.txt
+++ b/RareCppTest/CMakeLists.txt
@@ -9,6 +9,7 @@ set(Headers
 set(Sources
   builder_test.cpp
   edit_test.cpp
+  editor_attach_test.cpp
   editor_notifications_test.cpp
   extended_type_support_test.cpp
   flat_mdspan_test.cpp

--- a/RareCppTest/RareCppTest.vcxproj
+++ b/RareCppTest/RareCppTest.vcxproj
@@ -190,6 +190,7 @@
     <ClCompile Include="editor_notifications_test.cpp" />
     <ClCompile Include="edit_test.cpp" />
     <ClCompile Include="extended_type_support_test.cpp" />
+    <ClCompile Include="flat_mdspan_test.cpp" />
     <ClCompile Include="member_test.cpp" />
     <ClCompile Include="generic_macro_test.cpp" />
     <ClCompile Include="inherit_test.cpp" />

--- a/RareCppTest/RareCppTest.vcxproj
+++ b/RareCppTest/RareCppTest.vcxproj
@@ -187,6 +187,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="builder_test.cpp" />
+    <ClCompile Include="editor_attach_test.cpp" />
     <ClCompile Include="editor_notifications_test.cpp" />
     <ClCompile Include="edit_test.cpp" />
     <ClCompile Include="extended_type_support_test.cpp" />

--- a/RareCppTest/RareCppTest.vcxproj.filters
+++ b/RareCppTest/RareCppTest.vcxproj.filters
@@ -95,6 +95,9 @@
     <ClCompile Include="flat_mdspan_test.cpp">
       <Filter>Source Files\EditorTest</Filter>
     </ClCompile>
+    <ClCompile Include="editor_attach_test.cpp">
+      <Filter>Source Files\EditorTest</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="json_input_test.h">

--- a/RareCppTest/RareCppTest.vcxproj.filters
+++ b/RareCppTest/RareCppTest.vcxproj.filters
@@ -21,6 +21,9 @@
     <Filter Include="Source Files\JsonTest\definition">
       <UniqueIdentifier>{e908698b-aa91-4fe9-b3a5-b79599f34b2e}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\EditorTest">
+      <UniqueIdentifier>{6771ea9a-f8b3-43a4-8bb7-3514430588f1}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="json_input_test_buffered.cpp">
@@ -84,10 +87,13 @@
       <Filter>Source Files\ReflectTest</Filter>
     </ClCompile>
     <ClCompile Include="edit_test.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\EditorTest</Filter>
     </ClCompile>
     <ClCompile Include="editor_notifications_test.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\EditorTest</Filter>
+    </ClCompile>
+    <ClCompile Include="flat_mdspan_test.cpp">
+      <Filter>Source Files\EditorTest</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/RareCppTest/edit_test.cpp
+++ b/RareCppTest/edit_test.cpp
@@ -33,7 +33,7 @@ namespace EditorCumulative
 
         EXPECT_EQ(check.redoCount, 0);
         EXPECT_EQ(check.redoSize, 0);
-        EXPECT_TRUE(check.actionFirstEvent.empty());
+        EXPECT_TRUE(check.actions.empty());
     }
 
     TEST(UndoRedoElision, A)
@@ -44,8 +44,8 @@ namespace EditorCumulative
 
         EXPECT_EQ(check.redoCount, 0);
         EXPECT_EQ(check.redoSize, 0);
-        EXPECT_EQ(check.actionFirstEvent.size(), 1);
-        EXPECT_EQ(check.actionFirstEvent[0], 0);
+        EXPECT_EQ(check.actions.size(), 1);
+        EXPECT_EQ(check.actions[0].firstEventIndex, 0);
     }
 
     TEST(UndoRedoElision, AU)
@@ -57,8 +57,8 @@ namespace EditorCumulative
 
         EXPECT_EQ(check.redoCount, 1);
         EXPECT_EQ(check.redoSize, 1);
-        EXPECT_EQ(check.actionFirstEvent.size(), 1);
-        EXPECT_EQ(check.actionFirstEvent[0], 0);
+        EXPECT_EQ(check.actions.size(), 1);
+        EXPECT_EQ(check.actions[0].firstEventIndex, 0);
     }
 
     TEST(UndoRedoElision, AUA)
@@ -71,10 +71,10 @@ namespace EditorCumulative
 
         EXPECT_EQ(check.redoCount, 0);
         EXPECT_EQ(check.redoSize, 0);
-        EXPECT_EQ(check.actionFirstEvent.size(), 3);
-        EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[2], 1);
+        EXPECT_EQ(check.actions.size(), 3);
+        EXPECT_EQ(check.actions[0].firstEventIndex, 0);
+        EXPECT_EQ(check.actions[1].firstEventIndex, check.flagElidedRedos | 1);
+        EXPECT_EQ(check.actions[2].firstEventIndex, 1);
     }
 
     TEST(UndoRedoElision, AUR)
@@ -87,8 +87,8 @@ namespace EditorCumulative
 
         EXPECT_EQ(check.redoCount, 0);
         EXPECT_EQ(check.redoSize, 0);
-        EXPECT_EQ(check.actionFirstEvent.size(), 1);
-        EXPECT_EQ(check.actionFirstEvent[0], 0);
+        EXPECT_EQ(check.actions.size(), 1);
+        EXPECT_EQ(check.actions[0].firstEventIndex, 0);
     }
 
     TEST(UndoRedoElision, AA)
@@ -100,9 +100,9 @@ namespace EditorCumulative
 
         EXPECT_EQ(check.redoCount, 0);
         EXPECT_EQ(check.redoSize, 0);
-        EXPECT_EQ(check.actionFirstEvent.size(), 2);
-        EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 1);
+        EXPECT_EQ(check.actions.size(), 2);
+        EXPECT_EQ(check.actions[0].firstEventIndex, 0);
+        EXPECT_EQ(check.actions[1].firstEventIndex, 1);
     }
 
     TEST(UndoRedoElision, AAU)
@@ -115,9 +115,9 @@ namespace EditorCumulative
 
         EXPECT_EQ(check.redoCount, 1);
         EXPECT_EQ(check.redoSize, 1);
-        EXPECT_EQ(check.actionFirstEvent.size(), 2);
-        EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 1);
+        EXPECT_EQ(check.actions.size(), 2);
+        EXPECT_EQ(check.actions[0].firstEventIndex, 0);
+        EXPECT_EQ(check.actions[1].firstEventIndex, 1);
     }
 
     TEST(UndoRedoElision, AAUA)
@@ -131,11 +131,11 @@ namespace EditorCumulative
 
         EXPECT_EQ(check.redoCount, 0);
         EXPECT_EQ(check.redoSize, 0);
-        EXPECT_EQ(check.actionFirstEvent.size(), 4);
-        EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 1);
-        EXPECT_EQ(check.actionFirstEvent[2], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[3], 2);
+        EXPECT_EQ(check.actions.size(), 4);
+        EXPECT_EQ(check.actions[0].firstEventIndex, 0);
+        EXPECT_EQ(check.actions[1].firstEventIndex, 1);
+        EXPECT_EQ(check.actions[2].firstEventIndex, check.flagElidedRedos | 1);
+        EXPECT_EQ(check.actions[3].firstEventIndex, 2);
     }
 
     TEST(UndoRedoElision, AAUAU)
@@ -150,11 +150,11 @@ namespace EditorCumulative
 
         EXPECT_EQ(check.redoCount, 1);
         EXPECT_EQ(check.redoSize, 1);
-        EXPECT_EQ(check.actionFirstEvent.size(), 4);
-        EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 1);
-        EXPECT_EQ(check.actionFirstEvent[2], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[3], 2);
+        EXPECT_EQ(check.actions.size(), 4);
+        EXPECT_EQ(check.actions[0].firstEventIndex, 0);
+        EXPECT_EQ(check.actions[1].firstEventIndex, 1);
+        EXPECT_EQ(check.actions[2].firstEventIndex, check.flagElidedRedos | 1);
+        EXPECT_EQ(check.actions[3].firstEventIndex, 2);
     }
 
     TEST(UndoRedoElision, AAUAUU)
@@ -170,11 +170,11 @@ namespace EditorCumulative
 
         EXPECT_EQ(check.redoCount, 2);
         EXPECT_EQ(check.redoSize, 4);
-        EXPECT_EQ(check.actionFirstEvent.size(), 4);
-        EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 1);
-        EXPECT_EQ(check.actionFirstEvent[2], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[3], 2);
+        EXPECT_EQ(check.actions.size(), 4);
+        EXPECT_EQ(check.actions[0].firstEventIndex, 0);
+        EXPECT_EQ(check.actions[1].firstEventIndex, 1);
+        EXPECT_EQ(check.actions[2].firstEventIndex, check.flagElidedRedos | 1);
+        EXPECT_EQ(check.actions[3].firstEventIndex, 2);
     }
 
     TEST(UndoRedoElision, AAUAUUA)
@@ -191,13 +191,13 @@ namespace EditorCumulative
 
         EXPECT_EQ(check.redoCount, 0);
         EXPECT_EQ(check.redoSize, 0);
-        EXPECT_EQ(check.actionFirstEvent.size(), 6);
-        EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 1);
-        EXPECT_EQ(check.actionFirstEvent[2], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[3], 2);
-        EXPECT_EQ(check.actionFirstEvent[4], check.flagElidedRedos | 4);
-        EXPECT_EQ(check.actionFirstEvent[5], 3);
+        EXPECT_EQ(check.actions.size(), 6);
+        EXPECT_EQ(check.actions[0].firstEventIndex, 0);
+        EXPECT_EQ(check.actions[1].firstEventIndex, 1);
+        EXPECT_EQ(check.actions[2].firstEventIndex, check.flagElidedRedos | 1);
+        EXPECT_EQ(check.actions[3].firstEventIndex, 2);
+        EXPECT_EQ(check.actions[4].firstEventIndex, check.flagElidedRedos | 4);
+        EXPECT_EQ(check.actions[5].firstEventIndex, 3);
     }
 
     TEST(UndoRedoElision, AAUAUA)
@@ -213,13 +213,13 @@ namespace EditorCumulative
 
         EXPECT_EQ(check.redoCount, 0);
         EXPECT_EQ(check.redoSize, 0);
-        EXPECT_EQ(check.actionFirstEvent.size(), 6);
-        EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 1);
-        EXPECT_EQ(check.actionFirstEvent[2], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[3], 2);
-        EXPECT_EQ(check.actionFirstEvent[4], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[5], 3);
+        EXPECT_EQ(check.actions.size(), 6);
+        EXPECT_EQ(check.actions[0].firstEventIndex, 0);
+        EXPECT_EQ(check.actions[1].firstEventIndex, 1);
+        EXPECT_EQ(check.actions[2].firstEventIndex, check.flagElidedRedos | 1);
+        EXPECT_EQ(check.actions[3].firstEventIndex, 2);
+        EXPECT_EQ(check.actions[4].firstEventIndex, check.flagElidedRedos | 1);
+        EXPECT_EQ(check.actions[5].firstEventIndex, 3);
     }
 
     TEST(UndoRedoElision, AAUAUAU)
@@ -236,13 +236,13 @@ namespace EditorCumulative
 
         EXPECT_EQ(check.redoCount, 1);
         EXPECT_EQ(check.redoSize, 1);
-        EXPECT_EQ(check.actionFirstEvent.size(), 6);
-        EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 1);
-        EXPECT_EQ(check.actionFirstEvent[2], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[3], 2);
-        EXPECT_EQ(check.actionFirstEvent[4], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[5], 3);
+        EXPECT_EQ(check.actions.size(), 6);
+        EXPECT_EQ(check.actions[0].firstEventIndex, 0);
+        EXPECT_EQ(check.actions[1].firstEventIndex, 1);
+        EXPECT_EQ(check.actions[2].firstEventIndex, check.flagElidedRedos | 1);
+        EXPECT_EQ(check.actions[3].firstEventIndex, 2);
+        EXPECT_EQ(check.actions[4].firstEventIndex, check.flagElidedRedos | 1);
+        EXPECT_EQ(check.actions[5].firstEventIndex, 3);
     }
 
     TEST(UndoRedoElision, AAUAUAUU)
@@ -260,13 +260,13 @@ namespace EditorCumulative
 
         EXPECT_EQ(check.redoCount, 2);
         EXPECT_EQ(check.redoSize, 6);
-        EXPECT_EQ(check.actionFirstEvent.size(), 6);
-        EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 1);
-        EXPECT_EQ(check.actionFirstEvent[2], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[3], 2);
-        EXPECT_EQ(check.actionFirstEvent[4], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[5], 3);
+        EXPECT_EQ(check.actions.size(), 6);
+        EXPECT_EQ(check.actions[0].firstEventIndex, 0);
+        EXPECT_EQ(check.actions[1].firstEventIndex, 1);
+        EXPECT_EQ(check.actions[2].firstEventIndex, check.flagElidedRedos | 1);
+        EXPECT_EQ(check.actions[3].firstEventIndex, 2);
+        EXPECT_EQ(check.actions[4].firstEventIndex, check.flagElidedRedos | 1);
+        EXPECT_EQ(check.actions[5].firstEventIndex, 3);
     }
 
     TEST(UndoRedoElision, AAUAUAUUA)
@@ -285,15 +285,15 @@ namespace EditorCumulative
 
         EXPECT_EQ(check.redoCount, 0);
         EXPECT_EQ(check.redoSize, 0);
-        EXPECT_EQ(check.actionFirstEvent.size(), 8);
-        EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 1);
-        EXPECT_EQ(check.actionFirstEvent[2], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[3], 2);
-        EXPECT_EQ(check.actionFirstEvent[4], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[5], 3);
-        EXPECT_EQ(check.actionFirstEvent[6], check.flagElidedRedos | 6);
-        EXPECT_EQ(check.actionFirstEvent[7], 4);
+        EXPECT_EQ(check.actions.size(), 8);
+        EXPECT_EQ(check.actions[0].firstEventIndex, 0);
+        EXPECT_EQ(check.actions[1].firstEventIndex, 1);
+        EXPECT_EQ(check.actions[2].firstEventIndex, check.flagElidedRedos | 1);
+        EXPECT_EQ(check.actions[3].firstEventIndex, 2);
+        EXPECT_EQ(check.actions[4].firstEventIndex, check.flagElidedRedos | 1);
+        EXPECT_EQ(check.actions[5].firstEventIndex, 3);
+        EXPECT_EQ(check.actions[6].firstEventIndex, check.flagElidedRedos | 6);
+        EXPECT_EQ(check.actions[7].firstEventIndex, 4);
     }
 
     TEST(UndoRedoElision, AAUAA)
@@ -308,12 +308,12 @@ namespace EditorCumulative
 
         EXPECT_EQ(check.redoCount, 0);
         EXPECT_EQ(check.redoSize, 0);
-        EXPECT_EQ(check.actionFirstEvent.size(), 5);
-        EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 1);
-        EXPECT_EQ(check.actionFirstEvent[2], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[3], 2);
-        EXPECT_EQ(check.actionFirstEvent[4], 3);
+        EXPECT_EQ(check.actions.size(), 5);
+        EXPECT_EQ(check.actions[0].firstEventIndex, 0);
+        EXPECT_EQ(check.actions[1].firstEventIndex, 1);
+        EXPECT_EQ(check.actions[2].firstEventIndex, check.flagElidedRedos | 1);
+        EXPECT_EQ(check.actions[3].firstEventIndex, 2);
+        EXPECT_EQ(check.actions[4].firstEventIndex, 3);
     }
 
     TEST(UndoRedoElision, AAUAAU)
@@ -329,12 +329,12 @@ namespace EditorCumulative
 
         EXPECT_EQ(check.redoCount, 1);
         EXPECT_EQ(check.redoSize, 1);
-        EXPECT_EQ(check.actionFirstEvent.size(), 5);
-        EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 1);
-        EXPECT_EQ(check.actionFirstEvent[2], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[3], 2);
-        EXPECT_EQ(check.actionFirstEvent[4], 3);
+        EXPECT_EQ(check.actions.size(), 5);
+        EXPECT_EQ(check.actions[0].firstEventIndex, 0);
+        EXPECT_EQ(check.actions[1].firstEventIndex, 1);
+        EXPECT_EQ(check.actions[2].firstEventIndex, check.flagElidedRedos | 1);
+        EXPECT_EQ(check.actions[3].firstEventIndex, 2);
+        EXPECT_EQ(check.actions[4].firstEventIndex, 3);
     }
 
     TEST(UndoRedoElision, AAUAAUA)
@@ -351,14 +351,14 @@ namespace EditorCumulative
 
         EXPECT_EQ(check.redoCount, 0);
         EXPECT_EQ(check.redoSize, 0);
-        EXPECT_EQ(check.actionFirstEvent.size(), 7);
-        EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 1);
-        EXPECT_EQ(check.actionFirstEvent[2], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[3], 2);
-        EXPECT_EQ(check.actionFirstEvent[4], 3);
-        EXPECT_EQ(check.actionFirstEvent[5], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[6], 4);
+        EXPECT_EQ(check.actions.size(), 7);
+        EXPECT_EQ(check.actions[0].firstEventIndex, 0);
+        EXPECT_EQ(check.actions[1].firstEventIndex, 1);
+        EXPECT_EQ(check.actions[2].firstEventIndex, check.flagElidedRedos | 1);
+        EXPECT_EQ(check.actions[3].firstEventIndex, 2);
+        EXPECT_EQ(check.actions[4].firstEventIndex, 3);
+        EXPECT_EQ(check.actions[5].firstEventIndex, check.flagElidedRedos | 1);
+        EXPECT_EQ(check.actions[6].firstEventIndex, 4);
     }
 
     TEST(UndoRedoElision, AAUAAUAU)
@@ -376,14 +376,14 @@ namespace EditorCumulative
 
         EXPECT_EQ(check.redoCount, 1);
         EXPECT_EQ(check.redoSize, 1);
-        EXPECT_EQ(check.actionFirstEvent.size(), 7);
-        EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 1);
-        EXPECT_EQ(check.actionFirstEvent[2], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[3], 2);
-        EXPECT_EQ(check.actionFirstEvent[4], 3);
-        EXPECT_EQ(check.actionFirstEvent[5], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[6], 4);
+        EXPECT_EQ(check.actions.size(), 7);
+        EXPECT_EQ(check.actions[0].firstEventIndex, 0);
+        EXPECT_EQ(check.actions[1].firstEventIndex, 1);
+        EXPECT_EQ(check.actions[2].firstEventIndex, check.flagElidedRedos | 1);
+        EXPECT_EQ(check.actions[3].firstEventIndex, 2);
+        EXPECT_EQ(check.actions[4].firstEventIndex, 3);
+        EXPECT_EQ(check.actions[5].firstEventIndex, check.flagElidedRedos | 1);
+        EXPECT_EQ(check.actions[6].firstEventIndex, 4);
     }
 
     TEST(UndoRedoElision, AAUAAUAUU)
@@ -402,14 +402,14 @@ namespace EditorCumulative
 
         EXPECT_EQ(check.redoCount, 2);
         EXPECT_EQ(check.redoSize, 4);
-        EXPECT_EQ(check.actionFirstEvent.size(), 7);
-        EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 1);
-        EXPECT_EQ(check.actionFirstEvent[2], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[3], 2);
-        EXPECT_EQ(check.actionFirstEvent[4], 3);
-        EXPECT_EQ(check.actionFirstEvent[5], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[6], 4);
+        EXPECT_EQ(check.actions.size(), 7);
+        EXPECT_EQ(check.actions[0].firstEventIndex, 0);
+        EXPECT_EQ(check.actions[1].firstEventIndex, 1);
+        EXPECT_EQ(check.actions[2].firstEventIndex, check.flagElidedRedos | 1);
+        EXPECT_EQ(check.actions[3].firstEventIndex, 2);
+        EXPECT_EQ(check.actions[4].firstEventIndex, 3);
+        EXPECT_EQ(check.actions[5].firstEventIndex, check.flagElidedRedos | 1);
+        EXPECT_EQ(check.actions[6].firstEventIndex, 4);
     }
 
     TEST(UndoRedoElision, AAUAAUAUUU)
@@ -429,14 +429,14 @@ namespace EditorCumulative
 
         EXPECT_EQ(check.redoCount, 3);
         EXPECT_EQ(check.redoSize, 7);
-        EXPECT_EQ(check.actionFirstEvent.size(), 7);
-        EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 1);
-        EXPECT_EQ(check.actionFirstEvent[2], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[3], 2);
-        EXPECT_EQ(check.actionFirstEvent[4], 3);
-        EXPECT_EQ(check.actionFirstEvent[5], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[6], 4);
+        EXPECT_EQ(check.actions.size(), 7);
+        EXPECT_EQ(check.actions[0].firstEventIndex, 0);
+        EXPECT_EQ(check.actions[1].firstEventIndex, 1);
+        EXPECT_EQ(check.actions[2].firstEventIndex, check.flagElidedRedos | 1);
+        EXPECT_EQ(check.actions[3].firstEventIndex, 2);
+        EXPECT_EQ(check.actions[4].firstEventIndex, 3);
+        EXPECT_EQ(check.actions[5].firstEventIndex, check.flagElidedRedos | 1);
+        EXPECT_EQ(check.actions[6].firstEventIndex, 4);
     }
 
     TEST(UndoRedoElision, AAUAAUAUUUA)
@@ -457,16 +457,16 @@ namespace EditorCumulative
 
         EXPECT_EQ(check.redoCount, 0);
         EXPECT_EQ(check.redoSize, 0);
-        EXPECT_EQ(check.actionFirstEvent.size(), 9);
-        EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 1);
-        EXPECT_EQ(check.actionFirstEvent[2], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[3], 2);
-        EXPECT_EQ(check.actionFirstEvent[4], 3);
-        EXPECT_EQ(check.actionFirstEvent[5], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[6], 4);
-        EXPECT_EQ(check.actionFirstEvent[7], check.flagElidedRedos | 7);
-        EXPECT_EQ(check.actionFirstEvent[8], 5);
+        EXPECT_EQ(check.actions.size(), 9);
+        EXPECT_EQ(check.actions[0].firstEventIndex, 0);
+        EXPECT_EQ(check.actions[1].firstEventIndex, 1);
+        EXPECT_EQ(check.actions[2].firstEventIndex, check.flagElidedRedos | 1);
+        EXPECT_EQ(check.actions[3].firstEventIndex, 2);
+        EXPECT_EQ(check.actions[4].firstEventIndex, 3);
+        EXPECT_EQ(check.actions[5].firstEventIndex, check.flagElidedRedos | 1);
+        EXPECT_EQ(check.actions[6].firstEventIndex, 4);
+        EXPECT_EQ(check.actions[7].firstEventIndex, check.flagElidedRedos | 7);
+        EXPECT_EQ(check.actions[8].firstEventIndex, 5);
     }
 
     NOTE(CumulativeTest, IndexSize<std::uint32_t>)

--- a/RareCppTest/edit_test.cpp
+++ b/RareCppTest/edit_test.cpp
@@ -469,7 +469,7 @@ namespace EditorCumulative
         EXPECT_EQ(check.actionFirstEvent[8], 0);
     }
 
-    NOTE(CumulativeTest, IndexSize<std::uint32_t>{})
+    NOTE(CumulativeTest, IndexSize<std::uint32_t>)
     struct CumulativeTest
     {
         struct Bar
@@ -499,10 +499,10 @@ namespace EditorCumulative
         std::string b = "asdf";
         std::vector<int> c {};
         Bar bar;
-        std::vector<Bar> barVec {}; NOTE(barVec, IndexSize<std::uint16_t>{})
+        std::vector<Bar> barVec {}; NOTE(barVec, IndexSize<std::uint16_t>)
         int intRay[5] {};
         int mdIntRay[2][3] {};
-        std::vector<Trig> trigs {}; NOTE(trigs, IndexSize<std::uint16_t>{})
+        std::vector<Trig> trigs {}; NOTE(trigs, IndexSize<std::uint16_t>)
 
         REFLECT_NOTED(CumulativeTest, a, b, c, bar, barVec, intRay, mdIntRay, trigs)
     };

--- a/RareCppTest/edit_test.cpp
+++ b/RareCppTest/edit_test.cpp
@@ -796,6 +796,78 @@ namespace EditorCumulative
         EXPECT_EQ(expected, obj->ints);
     }
 
+    TEST(OpDo, PlusEq)
+    {
+        TrackDoOp obj {};
+        obj()->ints.append(2);
+        EXPECT_EQ(obj->ints, std::vector{2});
+        obj()->ints[0] += 3;
+        EXPECT_EQ(obj->ints, std::vector{5});
+    }
+
+    TEST(OpDo, MinusEq)
+    {
+        TrackDoOp obj {};
+        obj()->ints.append(7);
+        EXPECT_EQ(obj->ints, std::vector{7});
+        obj()->ints[0] -= 2;
+        EXPECT_EQ(obj->ints, std::vector{5});
+    }
+
+    TEST(OpDo, MultEq)
+    {
+        TrackDoOp obj {};
+        obj()->ints.append(2);
+        EXPECT_EQ(obj->ints, std::vector{2});
+        obj()->ints[0] *= 2;
+        EXPECT_EQ(obj->ints, std::vector{4});
+    }
+
+    TEST(OpDo, DivEq)
+    {
+        TrackDoOp obj {};
+        obj()->ints.append(4);
+        EXPECT_EQ(obj->ints, std::vector{4});
+        obj()->ints[0] /= 2;
+        EXPECT_EQ(obj->ints, std::vector{2});
+    }
+
+    TEST(OpDo, ModEq)
+    {
+        TrackDoOp obj {};
+        obj()->ints.append(5);
+        EXPECT_EQ(obj->ints, std::vector{5});
+        obj()->ints[0] %= 2;
+        EXPECT_EQ(obj->ints, std::vector{1});
+    }
+
+    TEST(OpDo, XorEq)
+    {
+        TrackDoOp obj {};
+        obj()->ints.append(0b01);
+        EXPECT_EQ(obj->ints, std::vector{0b01});
+        obj()->ints[0] ^= 0b11;
+        EXPECT_EQ(obj->ints, std::vector{0b10});
+    }
+
+    TEST(OpDo, AndEq)
+    {
+        TrackDoOp obj {};
+        obj()->ints.append(0b101);
+        EXPECT_EQ(obj->ints, std::vector{0b101});
+        obj()->ints[0] &= 0b011;
+        EXPECT_EQ(obj->ints, std::vector{0b001});
+    }
+
+    TEST(OpDo, OrEq)
+    {
+        TrackDoOp obj {};
+        obj()->ints.append(0b00);
+        EXPECT_EQ(obj->ints, std::vector{0b00});
+        obj()->ints[0] |= 0b11;
+        EXPECT_EQ(obj->ints, std::vector{0b11});
+    }
+
     TEST(OpDo, Append)
     {
         TrackDoOp obj {};
@@ -1812,6 +1884,118 @@ namespace EditorCumulative
         EXPECT_EQ(values, obj->ints);
         obj.redoAction();
         EXPECT_EQ(expected, obj->ints);
+    }
+    
+    TEST(OpUndoRedo, PlusEq)
+    {
+        TrackDoOp obj {};
+        obj()->ints.append(2);
+        EXPECT_EQ(obj->ints, std::vector{2});
+        obj()->ints[0] += 3;
+        EXPECT_EQ(obj->ints, std::vector{5});
+
+        obj.undoAction();
+        EXPECT_EQ(obj->ints, std::vector{2});
+        obj.redoAction();
+        EXPECT_EQ(obj->ints, std::vector{5});
+    }
+
+    TEST(OpUndoRedo, MinusEq)
+    {
+        TrackDoOp obj {};
+        obj()->ints.append(7);
+        EXPECT_EQ(obj->ints, std::vector{7});
+        obj()->ints[0] -= 2;
+        EXPECT_EQ(obj->ints, std::vector{5});
+
+        obj.undoAction();
+        EXPECT_EQ(obj->ints, std::vector{7});
+        obj.redoAction();
+        EXPECT_EQ(obj->ints, std::vector{5});
+    }
+
+    TEST(OpUndoRedo, MultEq)
+    {
+        TrackDoOp obj {};
+        obj()->ints.append(2);
+        EXPECT_EQ(obj->ints, std::vector{2});
+        obj()->ints[0] *= 2;
+        EXPECT_EQ(obj->ints, std::vector{4});
+
+        obj.undoAction();
+        EXPECT_EQ(obj->ints, std::vector{2});
+        obj.redoAction();
+        EXPECT_EQ(obj->ints, std::vector{4});
+    }
+
+    TEST(OpUndoRedo, DivEq)
+    {
+        TrackDoOp obj {};
+        obj()->ints.append(4);
+        EXPECT_EQ(obj->ints, std::vector{4});
+        obj()->ints[0] /= 2;
+        EXPECT_EQ(obj->ints, std::vector{2});
+
+        obj.undoAction();
+        EXPECT_EQ(obj->ints, std::vector{4});
+        obj.redoAction();
+        EXPECT_EQ(obj->ints, std::vector{2});
+    }
+
+    TEST(OpUndoRedo, ModEq)
+    {
+        TrackDoOp obj {};
+        obj()->ints.append(5);
+        EXPECT_EQ(obj->ints, std::vector{5});
+        obj()->ints[0] %= 2;
+        EXPECT_EQ(obj->ints, std::vector{1});
+
+        obj.undoAction();
+        EXPECT_EQ(obj->ints, std::vector{5});
+        obj.redoAction();
+        EXPECT_EQ(obj->ints, std::vector{1});
+    }
+
+    TEST(OpUndoRedo, XorEq)
+    {
+        TrackDoOp obj {};
+        obj()->ints.append(0b01);
+        EXPECT_EQ(obj->ints, std::vector{0b01});
+        obj()->ints[0] ^= 0b11;
+        EXPECT_EQ(obj->ints, std::vector{0b10});
+
+        obj.undoAction();
+        EXPECT_EQ(obj->ints, std::vector{0b01});
+        obj.redoAction();
+        EXPECT_EQ(obj->ints, std::vector{0b10});
+    }
+
+    TEST(OpUndoRedo, AndEq)
+    {
+        TrackDoOp obj {};
+        obj()->ints.append(0b101);
+        EXPECT_EQ(obj->ints, std::vector{0b101});
+        obj()->ints[0] &= 0b011;
+        EXPECT_EQ(obj->ints, std::vector{0b001});
+
+        obj.undoAction();
+        EXPECT_EQ(obj->ints, std::vector{0b101});
+        obj.redoAction();
+        EXPECT_EQ(obj->ints, std::vector{0b001});
+    }
+
+    TEST(OpUndoRedo, OrEq)
+    {
+        TrackDoOp obj {};
+        obj()->ints.append(0b00);
+        EXPECT_EQ(obj->ints, std::vector{0b00});
+        obj()->ints[0] |= 0b11;
+        EXPECT_EQ(obj->ints, std::vector{0b11});
+
+        obj.undoAction();
+        EXPECT_EQ(obj->ints, std::vector{0b00});
+        obj.redoAction();
+        EXPECT_EQ(obj->ints, std::vector{0b11});
     }
 
     TEST(OpUndoRedo, Append)
@@ -4724,5 +4908,461 @@ namespace EditorCumulative
         EXPECT_EQ(expectedSel, obj.view.ints.sel());
     }
 
-}
+    struct MdArrayTest
+    {
+        int twoD[3][2] {{11, 22}, {33, 44}, {55, 66}};
+        int threeD[4][3][2] {
+            {{11, 22}, {33, 44}, {55, 66}},
+            {{111, 222}, {333, 444}, {555, 666}},
+            {{1111, 2222}, {3333, 4444}, {5555, 6666}},
+            {{11111, 22222}, {33333, 44444}, {55555, 66666}}
+        };
 
+        REFLECT(MdArrayTest, twoD, threeD)
+    };
+
+    struct EditMdArrayTest : Tracked<MdArrayTest, EditMdArrayTest>
+    {
+        EditMdArrayTest() : Tracked{this} {}
+    };
+    
+    TEST(MdArray, Reset)
+    {
+        EditMdArrayTest myObj {};
+        EXPECT_EQ(myObj->twoD[0][0], 11);
+        EXPECT_EQ(myObj->twoD[0][1], 22);
+        EXPECT_EQ(myObj->twoD[1][0], 33);
+        EXPECT_EQ(myObj->twoD[1][1], 44);
+        EXPECT_EQ(myObj->twoD[2][0], 55);
+        EXPECT_EQ(myObj->twoD[2][1], 66);
+        EXPECT_EQ(myObj->threeD[0][0][0], 11);
+        EXPECT_EQ(myObj->threeD[0][0][1], 22);
+        EXPECT_EQ(myObj->threeD[0][1][0], 33);
+        EXPECT_EQ(myObj->threeD[0][1][1], 44);
+        EXPECT_EQ(myObj->threeD[0][2][0], 55);
+        EXPECT_EQ(myObj->threeD[0][2][1], 66);
+        EXPECT_EQ(myObj->threeD[1][0][0], 111);
+        EXPECT_EQ(myObj->threeD[1][0][1], 222);
+        EXPECT_EQ(myObj->threeD[1][1][0], 333);
+        EXPECT_EQ(myObj->threeD[1][1][1], 444);
+        EXPECT_EQ(myObj->threeD[1][2][0], 555);
+        EXPECT_EQ(myObj->threeD[1][2][1], 666);
+        EXPECT_EQ(myObj->threeD[2][0][0], 1111);
+        EXPECT_EQ(myObj->threeD[2][0][1], 2222);
+        EXPECT_EQ(myObj->threeD[2][1][0], 3333);
+        EXPECT_EQ(myObj->threeD[2][1][1], 4444);
+        EXPECT_EQ(myObj->threeD[2][2][0], 5555);
+        EXPECT_EQ(myObj->threeD[2][2][1], 6666);
+        EXPECT_EQ(myObj->threeD[3][0][0], 11111);
+        EXPECT_EQ(myObj->threeD[3][0][1], 22222);
+        EXPECT_EQ(myObj->threeD[3][1][0], 33333);
+        EXPECT_EQ(myObj->threeD[3][1][1], 44444);
+        EXPECT_EQ(myObj->threeD[3][2][0], 55555);
+        EXPECT_EQ(myObj->threeD[3][2][1], 66666);
+        
+        myObj()->twoD.reset();
+        myObj()->threeD.reset();
+        EXPECT_EQ(myObj->twoD[0][0], 0);
+        EXPECT_EQ(myObj->twoD[0][1], 0);
+        EXPECT_EQ(myObj->twoD[1][0], 0);
+        EXPECT_EQ(myObj->twoD[1][1], 0);
+        EXPECT_EQ(myObj->twoD[2][0], 0);
+        EXPECT_EQ(myObj->twoD[2][1], 0);
+        EXPECT_EQ(myObj->threeD[0][0][0], 0);
+        EXPECT_EQ(myObj->threeD[0][0][1], 0);
+        EXPECT_EQ(myObj->threeD[0][1][0], 0);
+        EXPECT_EQ(myObj->threeD[0][1][1], 0);
+        EXPECT_EQ(myObj->threeD[0][2][0], 0);
+        EXPECT_EQ(myObj->threeD[0][2][1], 0);
+        EXPECT_EQ(myObj->threeD[1][0][0], 0);
+        EXPECT_EQ(myObj->threeD[1][0][1], 0);
+        EXPECT_EQ(myObj->threeD[1][1][0], 0);
+        EXPECT_EQ(myObj->threeD[1][1][1], 0);
+        EXPECT_EQ(myObj->threeD[1][2][0], 0);
+        EXPECT_EQ(myObj->threeD[1][2][1], 0);
+        EXPECT_EQ(myObj->threeD[2][0][0], 0);
+        EXPECT_EQ(myObj->threeD[2][0][1], 0);
+        EXPECT_EQ(myObj->threeD[2][1][0], 0);
+        EXPECT_EQ(myObj->threeD[2][1][1], 0);
+        EXPECT_EQ(myObj->threeD[2][2][0], 0);
+        EXPECT_EQ(myObj->threeD[2][2][1], 0);
+        EXPECT_EQ(myObj->threeD[3][0][0], 0);
+        EXPECT_EQ(myObj->threeD[3][0][1], 0);
+        EXPECT_EQ(myObj->threeD[3][1][0], 0);
+        EXPECT_EQ(myObj->threeD[3][1][1], 0);
+        EXPECT_EQ(myObj->threeD[3][2][0], 0);
+        EXPECT_EQ(myObj->threeD[3][2][1], 0);
+
+        myObj.undoAction();
+        myObj.undoAction();
+        EXPECT_EQ(myObj->twoD[0][0], 11);
+        EXPECT_EQ(myObj->twoD[0][1], 22);
+        EXPECT_EQ(myObj->twoD[1][0], 33);
+        EXPECT_EQ(myObj->twoD[1][1], 44);
+        EXPECT_EQ(myObj->twoD[2][0], 55);
+        EXPECT_EQ(myObj->twoD[2][1], 66);
+        EXPECT_EQ(myObj->threeD[0][0][0], 11);
+        EXPECT_EQ(myObj->threeD[0][0][1], 22);
+        EXPECT_EQ(myObj->threeD[0][1][0], 33);
+        EXPECT_EQ(myObj->threeD[0][1][1], 44);
+        EXPECT_EQ(myObj->threeD[0][2][0], 55);
+        EXPECT_EQ(myObj->threeD[0][2][1], 66);
+        EXPECT_EQ(myObj->threeD[1][0][0], 111);
+        EXPECT_EQ(myObj->threeD[1][0][1], 222);
+        EXPECT_EQ(myObj->threeD[1][1][0], 333);
+        EXPECT_EQ(myObj->threeD[1][1][1], 444);
+        EXPECT_EQ(myObj->threeD[1][2][0], 555);
+        EXPECT_EQ(myObj->threeD[1][2][1], 666);
+        EXPECT_EQ(myObj->threeD[2][0][0], 1111);
+        EXPECT_EQ(myObj->threeD[2][0][1], 2222);
+        EXPECT_EQ(myObj->threeD[2][1][0], 3333);
+        EXPECT_EQ(myObj->threeD[2][1][1], 4444);
+        EXPECT_EQ(myObj->threeD[2][2][0], 5555);
+        EXPECT_EQ(myObj->threeD[2][2][1], 6666);
+        EXPECT_EQ(myObj->threeD[3][0][0], 11111);
+        EXPECT_EQ(myObj->threeD[3][0][1], 22222);
+        EXPECT_EQ(myObj->threeD[3][1][0], 33333);
+        EXPECT_EQ(myObj->threeD[3][1][1], 44444);
+        EXPECT_EQ(myObj->threeD[3][2][0], 55555);
+        EXPECT_EQ(myObj->threeD[3][2][1], 66666);
+
+        myObj.redoAction();
+        myObj.redoAction();
+        EXPECT_EQ(myObj->twoD[0][0], 0);
+        EXPECT_EQ(myObj->twoD[0][1], 0);
+        EXPECT_EQ(myObj->twoD[1][0], 0);
+        EXPECT_EQ(myObj->twoD[1][1], 0);
+        EXPECT_EQ(myObj->twoD[2][0], 0);
+        EXPECT_EQ(myObj->twoD[2][1], 0);
+        EXPECT_EQ(myObj->threeD[0][0][0], 0);
+        EXPECT_EQ(myObj->threeD[0][0][1], 0);
+        EXPECT_EQ(myObj->threeD[0][1][0], 0);
+        EXPECT_EQ(myObj->threeD[0][1][1], 0);
+        EXPECT_EQ(myObj->threeD[0][2][0], 0);
+        EXPECT_EQ(myObj->threeD[0][2][1], 0);
+        EXPECT_EQ(myObj->threeD[1][0][0], 0);
+        EXPECT_EQ(myObj->threeD[1][0][1], 0);
+        EXPECT_EQ(myObj->threeD[1][1][0], 0);
+        EXPECT_EQ(myObj->threeD[1][1][1], 0);
+        EXPECT_EQ(myObj->threeD[1][2][0], 0);
+        EXPECT_EQ(myObj->threeD[1][2][1], 0);
+        EXPECT_EQ(myObj->threeD[2][0][0], 0);
+        EXPECT_EQ(myObj->threeD[2][0][1], 0);
+        EXPECT_EQ(myObj->threeD[2][1][0], 0);
+        EXPECT_EQ(myObj->threeD[2][1][1], 0);
+        EXPECT_EQ(myObj->threeD[2][2][0], 0);
+        EXPECT_EQ(myObj->threeD[2][2][1], 0);
+        EXPECT_EQ(myObj->threeD[3][0][0], 0);
+        EXPECT_EQ(myObj->threeD[3][0][1], 0);
+        EXPECT_EQ(myObj->threeD[3][1][0], 0);
+        EXPECT_EQ(myObj->threeD[3][1][1], 0);
+        EXPECT_EQ(myObj->threeD[3][2][0], 0);
+        EXPECT_EQ(myObj->threeD[3][2][1], 0);
+    }
+
+    TEST(MdArray, Set)
+    {
+        EditMdArrayTest myObj {};
+        EXPECT_EQ(myObj->twoD[0][0], 11);
+        EXPECT_EQ(myObj->twoD[0][1], 22);
+        EXPECT_EQ(myObj->twoD[1][0], 33);
+        EXPECT_EQ(myObj->twoD[1][1], 44);
+        EXPECT_EQ(myObj->twoD[2][0], 55);
+        EXPECT_EQ(myObj->twoD[2][1], 66);
+        EXPECT_EQ(myObj->threeD[0][0][0], 11);
+        EXPECT_EQ(myObj->threeD[0][0][1], 22);
+        EXPECT_EQ(myObj->threeD[0][1][0], 33);
+        EXPECT_EQ(myObj->threeD[0][1][1], 44);
+        EXPECT_EQ(myObj->threeD[0][2][0], 55);
+        EXPECT_EQ(myObj->threeD[0][2][1], 66);
+        EXPECT_EQ(myObj->threeD[1][0][0], 111);
+        EXPECT_EQ(myObj->threeD[1][0][1], 222);
+        EXPECT_EQ(myObj->threeD[1][1][0], 333);
+        EXPECT_EQ(myObj->threeD[1][1][1], 444);
+        EXPECT_EQ(myObj->threeD[1][2][0], 555);
+        EXPECT_EQ(myObj->threeD[1][2][1], 666);
+        EXPECT_EQ(myObj->threeD[2][0][0], 1111);
+        EXPECT_EQ(myObj->threeD[2][0][1], 2222);
+        EXPECT_EQ(myObj->threeD[2][1][0], 3333);
+        EXPECT_EQ(myObj->threeD[2][1][1], 4444);
+        EXPECT_EQ(myObj->threeD[2][2][0], 5555);
+        EXPECT_EQ(myObj->threeD[2][2][1], 6666);
+        EXPECT_EQ(myObj->threeD[3][0][0], 11111);
+        EXPECT_EQ(myObj->threeD[3][0][1], 22222);
+        EXPECT_EQ(myObj->threeD[3][1][0], 33333);
+        EXPECT_EQ(myObj->threeD[3][1][1], 44444);
+        EXPECT_EQ(myObj->threeD[3][2][0], 55555);
+        EXPECT_EQ(myObj->threeD[3][2][1], 66666);
+        
+        myObj()->twoD[2][1] = 77;
+        myObj()->threeD[3][2][1] = 77777;
+        EXPECT_EQ(myObj->twoD[2][1], 77);
+        EXPECT_EQ(myObj->threeD[3][2][1], 77777);
+
+        myObj.undoAction();
+        myObj.undoAction();
+        EXPECT_EQ(myObj->twoD[2][1], 66);
+        EXPECT_EQ(myObj->threeD[3][2][1], 66666);
+
+        myObj.redoAction();
+        myObj.redoAction();
+        EXPECT_EQ(myObj->twoD[2][1], 77);
+        EXPECT_EQ(myObj->threeD[3][2][1], 77777);
+    }
+
+    struct InitDataTest
+    {
+        int a = 1;
+        std::vector<int> b = {2, 3};
+
+        REFLECT(InitDataTest, a, b)
+    };
+
+    struct EditInitDataTest : Tracked<InitDataTest, EditInitDataTest>
+    {
+        EditInitDataTest() : Tracked{this} {}
+    };
+
+    TEST(MiscEdits, InitData)
+    {
+        EditInitDataTest myObj {};
+        EXPECT_EQ(1, myObj->a);
+        std::vector<int> expectedVec {2, 3};
+        EXPECT_EQ(expectedVec, myObj->b);
+
+        myObj.initData<false>(InitDataTest {
+            .a = 4,
+            .b = {5, 6}
+        });
+        EXPECT_EQ(0, myObj.getCursorIndex());
+        EXPECT_EQ(4, myObj->a);
+        expectedVec = {5, 6};
+        EXPECT_EQ(expectedVec, myObj->b);
+
+        myObj.initData<true>(InitDataTest {
+            .a = 7,
+            .b = {8, 9}
+        });
+        EXPECT_EQ(1, myObj.getCursorIndex());
+        EXPECT_EQ(7, myObj->a);
+        expectedVec = {8, 9};
+        EXPECT_EQ(expectedVec, myObj->b);
+
+        myObj.undoAction();
+        EXPECT_EQ(0, myObj.getCursorIndex());
+        EXPECT_EQ(4, myObj->a);
+        expectedVec = {5, 6};
+        EXPECT_EQ(expectedVec, myObj->b);
+
+        myObj.redoAction();
+        EXPECT_EQ(1, myObj.getCursorIndex());
+        EXPECT_EQ(7, myObj->a);
+        expectedVec = {8, 9};
+        EXPECT_EQ(expectedVec, myObj->b);
+        
+        EXPECT_ANY_THROW(myObj.initData<false>(InitDataTest{}));
+        EXPECT_ANY_THROW(myObj.initData<true>(InitDataTest{}));
+
+        myObj.clearHistory();
+        myObj.initData<true>(InitDataTest{
+            .a = 10,
+            .b = {11, 12}
+        });
+        EXPECT_EQ(1, myObj.getCursorIndex());
+        EXPECT_EQ(10, myObj->a);
+        expectedVec = {11, 12};
+        EXPECT_EQ(expectedVec, myObj->b);
+
+        myObj.undoAction();
+        EXPECT_EQ(0, myObj.getCursorIndex());
+        EXPECT_EQ(7, myObj->a);
+        expectedVec = {8, 9};
+        EXPECT_EQ(expectedVec, myObj->b);
+
+        myObj.redoAction();
+        EXPECT_EQ(1, myObj.getCursorIndex());
+        EXPECT_EQ(10, myObj->a);
+        expectedVec = {11, 12};
+        EXPECT_EQ(expectedVec, myObj->b);
+
+        myObj.clearHistory();
+        myObj.initData<false>(InitDataTest{
+            .a = 13,
+            .b = {14, 15}
+        });
+        EXPECT_EQ(0, myObj.getCursorIndex());
+        EXPECT_EQ(13, myObj->a);
+        expectedVec = {14, 15};
+        EXPECT_EQ(expectedVec, myObj->b);
+    }
+
+    TEST(MiscEdits, RootAssign)
+    {
+        EditInitDataTest myObj {};
+        EXPECT_EQ(1, myObj->a);
+        std::vector<int> expectedVec {2, 3};
+        EXPECT_EQ(expectedVec, myObj->b);
+
+        myObj()->assign(InitDataTest{
+            .a = 4,
+            .b = {5, 6}
+        });
+        EXPECT_EQ(4, myObj->a);
+        expectedVec = {5, 6};
+        EXPECT_EQ(expectedVec, myObj->b);
+
+        myObj.undoAction();
+        EXPECT_EQ(1, myObj->a);
+        expectedVec = {2, 3};
+        EXPECT_EQ(expectedVec, myObj->b);
+
+        myObj.redoAction();
+        EXPECT_EQ(4, myObj->a);
+        expectedVec = {5, 6};
+        EXPECT_EQ(expectedVec, myObj->b);
+    }
+
+    struct OptionalTest
+    {
+        std::optional<int> a = 1;
+
+        REFLECT(OptionalTest, a)
+    };
+
+    struct EditOptionalTest : Tracked<OptionalTest, EditOptionalTest>
+    {
+        EditOptionalTest() : Tracked{this} {}
+    };
+
+    TEST(MiscEdits, OptionalTest)
+    {
+        EditOptionalTest myObj {};
+        EXPECT_EQ(myObj->a.value(), 1);
+        myObj()->a = std::nullopt;
+        EXPECT_EQ(myObj->a, std::nullopt);
+        myObj()->a = 2;
+        EXPECT_EQ(myObj->a.value(), 2);
+
+        myObj.undoAction();
+        EXPECT_EQ(myObj->a, std::nullopt);
+        myObj.undoAction();
+        EXPECT_EQ(myObj->a, 1);
+
+        myObj.redoAction();
+        EXPECT_EQ(myObj->a, std::nullopt);
+        myObj.redoAction();
+        EXPECT_EQ(myObj->a, 2);
+    }
+
+    struct Item
+    {
+        int hitCount;
+
+        REFLECT(Item, hitCount)
+    };
+
+    struct Actor
+    {
+        int xc = 0;
+        int yc = 0;
+        std::vector<Item> items {Item{}};
+
+        REFLECT(Actor, xc, yc, items)
+    };
+
+    struct MyObj
+    {
+        std::vector<Actor> actors {};
+
+        REFLECT(MyObj, actors)
+    };
+
+    struct TracedObj : Tracked<MyObj, TracedObj>
+    {
+        struct ItemElem : TrackedElement<Item, PATH(root->actors[0].items[0])>
+        {
+            using TrackedElement::TrackedElement;
+            void hit() { edit.hitCount = read.hitCount+1; }
+        };
+
+        struct ActorElem : TrackedElement<Actor, PATH(root->actors[0])>
+        {
+            using TrackedElement::TrackedElement;
+            void act() { edit.xc = read.xc+2; }
+            auto getItemElem(std::size_t i) { return ItemElem(this, view.items[i]); }
+        };
+
+        TracedObj() : Tracked{this} {}
+
+        ActorElem getActorElem(std::size_t i) {
+            return ActorElem(this, view.actors[i]);
+        }
+    };
+
+    TEST(MiscEdits, SubElemTest)
+    {
+        TracedObj myObj {};
+        myObj.initData<false>(MyObj{
+            .actors = {
+                Actor{.xc = 11, .yc = 33, .items = {{0}, {0}}},
+                Actor{.xc = 22, .yc = 44, .items = {{0}, {0}, {0}}}
+            }
+        });
+        {
+            auto editActor = myObj.getActorElem(1);
+            EXPECT_EQ(myObj->actors[1].xc, 22);
+            editActor.act();
+            EXPECT_EQ(myObj->actors[1].xc, 24);
+
+            auto editItem = editActor.getItemElem(2);
+            EXPECT_EQ(myObj->actors[1].items[2].hitCount, 0);
+            editItem.hit();
+            EXPECT_EQ(myObj->actors[1].items[2].hitCount, 1);
+        }
+        myObj.undoAction();
+        EXPECT_EQ(myObj->actors[1].xc, 22);
+        EXPECT_EQ(myObj->actors[1].items[2].hitCount, 0);
+        
+        myObj.redoAction();
+        EXPECT_EQ(myObj->actors[1].xc, 24);
+        EXPECT_EQ(myObj->actors[1].items[2].hitCount, 1);
+    }
+
+    struct UserDefinedData
+    {
+        std::string descr = "";
+
+        inline bool operator==(const UserDefinedData & other) const { return descr == other.descr; }
+    };
+
+    struct UserDefinedTest
+    {
+        int a = 0;
+
+        REFLECT(UserDefinedTest, a)
+    };
+
+    struct EditUserDefinedTest : Tracked<UserDefinedTest, EditUserDefinedTest, UserDefinedData>
+    {
+        EditUserDefinedTest() : Tracked{this} {}
+    };
+
+    TEST(MiscEdits, UserDefinedActionData)
+    {
+        EditUserDefinedTest myObj {};
+        {
+            auto edit = myObj.operator()({"labeled action"});
+            edit->a = 1;
+        }
+        RareEdit::RenderAction<UserDefinedData> renderAction {};
+        myObj.renderAction(0, renderAction, false);
+        EXPECT_STREQ(renderAction.userData.descr.c_str(), "labeled action");
+        {
+            auto edit = myObj.operator()({"another action"});
+            edit->a = 2;
+        }
+        myObj.renderAction(1, renderAction, false);
+        EXPECT_STREQ(renderAction.userData.descr.c_str(), "another action");
+    }
+
+}

--- a/RareCppTest/edit_test.cpp
+++ b/RareCppTest/edit_test.cpp
@@ -22,7 +22,7 @@ namespace EditorCumulative
 
         void act()
         {
-            createAction();
+            createAction()->a = 0;
         }
     };
 
@@ -74,7 +74,7 @@ namespace EditorCumulative
         EXPECT_EQ(check.actionFirstEvent.size(), 3);
         EXPECT_EQ(check.actionFirstEvent[0], 0);
         EXPECT_EQ(check.actionFirstEvent[1], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[2], 0);
+        EXPECT_EQ(check.actionFirstEvent[2], 1);
     }
 
     TEST(UndoRedoElision, AUR)
@@ -102,7 +102,7 @@ namespace EditorCumulative
         EXPECT_EQ(check.redoSize, 0);
         EXPECT_EQ(check.actionFirstEvent.size(), 2);
         EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 0);
+        EXPECT_EQ(check.actionFirstEvent[1], 1);
     }
 
     TEST(UndoRedoElision, AAU)
@@ -117,7 +117,7 @@ namespace EditorCumulative
         EXPECT_EQ(check.redoSize, 1);
         EXPECT_EQ(check.actionFirstEvent.size(), 2);
         EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 0);
+        EXPECT_EQ(check.actionFirstEvent[1], 1);
     }
 
     TEST(UndoRedoElision, AAUA)
@@ -133,9 +133,9 @@ namespace EditorCumulative
         EXPECT_EQ(check.redoSize, 0);
         EXPECT_EQ(check.actionFirstEvent.size(), 4);
         EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 0);
+        EXPECT_EQ(check.actionFirstEvent[1], 1);
         EXPECT_EQ(check.actionFirstEvent[2], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[3], 0);
+        EXPECT_EQ(check.actionFirstEvent[3], 2);
     }
 
     TEST(UndoRedoElision, AAUAU)
@@ -152,9 +152,9 @@ namespace EditorCumulative
         EXPECT_EQ(check.redoSize, 1);
         EXPECT_EQ(check.actionFirstEvent.size(), 4);
         EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 0);
+        EXPECT_EQ(check.actionFirstEvent[1], 1);
         EXPECT_EQ(check.actionFirstEvent[2], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[3], 0);
+        EXPECT_EQ(check.actionFirstEvent[3], 2);
     }
 
     TEST(UndoRedoElision, AAUAUU)
@@ -172,9 +172,9 @@ namespace EditorCumulative
         EXPECT_EQ(check.redoSize, 4);
         EXPECT_EQ(check.actionFirstEvent.size(), 4);
         EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 0);
+        EXPECT_EQ(check.actionFirstEvent[1], 1);
         EXPECT_EQ(check.actionFirstEvent[2], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[3], 0);
+        EXPECT_EQ(check.actionFirstEvent[3], 2);
     }
 
     TEST(UndoRedoElision, AAUAUUA)
@@ -193,11 +193,11 @@ namespace EditorCumulative
         EXPECT_EQ(check.redoSize, 0);
         EXPECT_EQ(check.actionFirstEvent.size(), 6);
         EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 0);
+        EXPECT_EQ(check.actionFirstEvent[1], 1);
         EXPECT_EQ(check.actionFirstEvent[2], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[3], 0);
+        EXPECT_EQ(check.actionFirstEvent[3], 2);
         EXPECT_EQ(check.actionFirstEvent[4], check.flagElidedRedos | 4);
-        EXPECT_EQ(check.actionFirstEvent[5], 0);
+        EXPECT_EQ(check.actionFirstEvent[5], 3);
     }
 
     TEST(UndoRedoElision, AAUAUA)
@@ -215,11 +215,11 @@ namespace EditorCumulative
         EXPECT_EQ(check.redoSize, 0);
         EXPECT_EQ(check.actionFirstEvent.size(), 6);
         EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 0);
+        EXPECT_EQ(check.actionFirstEvent[1], 1);
         EXPECT_EQ(check.actionFirstEvent[2], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[3], 0);
+        EXPECT_EQ(check.actionFirstEvent[3], 2);
         EXPECT_EQ(check.actionFirstEvent[4], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[5], 0);
+        EXPECT_EQ(check.actionFirstEvent[5], 3);
     }
 
     TEST(UndoRedoElision, AAUAUAU)
@@ -238,11 +238,11 @@ namespace EditorCumulative
         EXPECT_EQ(check.redoSize, 1);
         EXPECT_EQ(check.actionFirstEvent.size(), 6);
         EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 0);
+        EXPECT_EQ(check.actionFirstEvent[1], 1);
         EXPECT_EQ(check.actionFirstEvent[2], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[3], 0);
+        EXPECT_EQ(check.actionFirstEvent[3], 2);
         EXPECT_EQ(check.actionFirstEvent[4], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[5], 0);
+        EXPECT_EQ(check.actionFirstEvent[5], 3);
     }
 
     TEST(UndoRedoElision, AAUAUAUU)
@@ -262,11 +262,11 @@ namespace EditorCumulative
         EXPECT_EQ(check.redoSize, 6);
         EXPECT_EQ(check.actionFirstEvent.size(), 6);
         EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 0);
+        EXPECT_EQ(check.actionFirstEvent[1], 1);
         EXPECT_EQ(check.actionFirstEvent[2], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[3], 0);
+        EXPECT_EQ(check.actionFirstEvent[3], 2);
         EXPECT_EQ(check.actionFirstEvent[4], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[5], 0);
+        EXPECT_EQ(check.actionFirstEvent[5], 3);
     }
 
     TEST(UndoRedoElision, AAUAUAUUA)
@@ -287,13 +287,13 @@ namespace EditorCumulative
         EXPECT_EQ(check.redoSize, 0);
         EXPECT_EQ(check.actionFirstEvent.size(), 8);
         EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 0);
+        EXPECT_EQ(check.actionFirstEvent[1], 1);
         EXPECT_EQ(check.actionFirstEvent[2], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[3], 0);
+        EXPECT_EQ(check.actionFirstEvent[3], 2);
         EXPECT_EQ(check.actionFirstEvent[4], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[5], 0);
+        EXPECT_EQ(check.actionFirstEvent[5], 3);
         EXPECT_EQ(check.actionFirstEvent[6], check.flagElidedRedos | 6);
-        EXPECT_EQ(check.actionFirstEvent[7], 0);
+        EXPECT_EQ(check.actionFirstEvent[7], 4);
     }
 
     TEST(UndoRedoElision, AAUAA)
@@ -310,10 +310,10 @@ namespace EditorCumulative
         EXPECT_EQ(check.redoSize, 0);
         EXPECT_EQ(check.actionFirstEvent.size(), 5);
         EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 0);
+        EXPECT_EQ(check.actionFirstEvent[1], 1);
         EXPECT_EQ(check.actionFirstEvent[2], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[3], 0);
-        EXPECT_EQ(check.actionFirstEvent[4], 0);
+        EXPECT_EQ(check.actionFirstEvent[3], 2);
+        EXPECT_EQ(check.actionFirstEvent[4], 3);
     }
 
     TEST(UndoRedoElision, AAUAAU)
@@ -331,10 +331,10 @@ namespace EditorCumulative
         EXPECT_EQ(check.redoSize, 1);
         EXPECT_EQ(check.actionFirstEvent.size(), 5);
         EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 0);
+        EXPECT_EQ(check.actionFirstEvent[1], 1);
         EXPECT_EQ(check.actionFirstEvent[2], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[3], 0);
-        EXPECT_EQ(check.actionFirstEvent[4], 0);
+        EXPECT_EQ(check.actionFirstEvent[3], 2);
+        EXPECT_EQ(check.actionFirstEvent[4], 3);
     }
 
     TEST(UndoRedoElision, AAUAAUA)
@@ -353,12 +353,12 @@ namespace EditorCumulative
         EXPECT_EQ(check.redoSize, 0);
         EXPECT_EQ(check.actionFirstEvent.size(), 7);
         EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 0);
+        EXPECT_EQ(check.actionFirstEvent[1], 1);
         EXPECT_EQ(check.actionFirstEvent[2], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[3], 0);
-        EXPECT_EQ(check.actionFirstEvent[4], 0);
+        EXPECT_EQ(check.actionFirstEvent[3], 2);
+        EXPECT_EQ(check.actionFirstEvent[4], 3);
         EXPECT_EQ(check.actionFirstEvent[5], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[6], 0);
+        EXPECT_EQ(check.actionFirstEvent[6], 4);
     }
 
     TEST(UndoRedoElision, AAUAAUAU)
@@ -378,12 +378,12 @@ namespace EditorCumulative
         EXPECT_EQ(check.redoSize, 1);
         EXPECT_EQ(check.actionFirstEvent.size(), 7);
         EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 0);
+        EXPECT_EQ(check.actionFirstEvent[1], 1);
         EXPECT_EQ(check.actionFirstEvent[2], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[3], 0);
-        EXPECT_EQ(check.actionFirstEvent[4], 0);
+        EXPECT_EQ(check.actionFirstEvent[3], 2);
+        EXPECT_EQ(check.actionFirstEvent[4], 3);
         EXPECT_EQ(check.actionFirstEvent[5], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[6], 0);
+        EXPECT_EQ(check.actionFirstEvent[6], 4);
     }
 
     TEST(UndoRedoElision, AAUAAUAUU)
@@ -404,12 +404,12 @@ namespace EditorCumulative
         EXPECT_EQ(check.redoSize, 4);
         EXPECT_EQ(check.actionFirstEvent.size(), 7);
         EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 0);
+        EXPECT_EQ(check.actionFirstEvent[1], 1);
         EXPECT_EQ(check.actionFirstEvent[2], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[3], 0);
-        EXPECT_EQ(check.actionFirstEvent[4], 0);
+        EXPECT_EQ(check.actionFirstEvent[3], 2);
+        EXPECT_EQ(check.actionFirstEvent[4], 3);
         EXPECT_EQ(check.actionFirstEvent[5], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[6], 0);
+        EXPECT_EQ(check.actionFirstEvent[6], 4);
     }
 
     TEST(UndoRedoElision, AAUAAUAUUU)
@@ -431,12 +431,12 @@ namespace EditorCumulative
         EXPECT_EQ(check.redoSize, 7);
         EXPECT_EQ(check.actionFirstEvent.size(), 7);
         EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 0);
+        EXPECT_EQ(check.actionFirstEvent[1], 1);
         EXPECT_EQ(check.actionFirstEvent[2], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[3], 0);
-        EXPECT_EQ(check.actionFirstEvent[4], 0);
+        EXPECT_EQ(check.actionFirstEvent[3], 2);
+        EXPECT_EQ(check.actionFirstEvent[4], 3);
         EXPECT_EQ(check.actionFirstEvent[5], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[6], 0);
+        EXPECT_EQ(check.actionFirstEvent[6], 4);
     }
 
     TEST(UndoRedoElision, AAUAAUAUUUA)
@@ -459,14 +459,14 @@ namespace EditorCumulative
         EXPECT_EQ(check.redoSize, 0);
         EXPECT_EQ(check.actionFirstEvent.size(), 9);
         EXPECT_EQ(check.actionFirstEvent[0], 0);
-        EXPECT_EQ(check.actionFirstEvent[1], 0);
+        EXPECT_EQ(check.actionFirstEvent[1], 1);
         EXPECT_EQ(check.actionFirstEvent[2], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[3], 0);
-        EXPECT_EQ(check.actionFirstEvent[4], 0);
+        EXPECT_EQ(check.actionFirstEvent[3], 2);
+        EXPECT_EQ(check.actionFirstEvent[4], 3);
         EXPECT_EQ(check.actionFirstEvent[5], check.flagElidedRedos | 1);
-        EXPECT_EQ(check.actionFirstEvent[6], 0);
+        EXPECT_EQ(check.actionFirstEvent[6], 4);
         EXPECT_EQ(check.actionFirstEvent[7], check.flagElidedRedos | 7);
-        EXPECT_EQ(check.actionFirstEvent[8], 0);
+        EXPECT_EQ(check.actionFirstEvent[8], 5);
     }
 
     NOTE(CumulativeTest, IndexSize<std::uint32_t>)

--- a/RareCppTest/edit_test.cpp
+++ b/RareCppTest/edit_test.cpp
@@ -900,6 +900,15 @@ namespace EditorCumulative
         EXPECT_EQ(expected, obj->ints);
     }
 
+    TEST(OpDo, Swap)
+    {
+        TrackDoOp obj {};
+        obj()->ints = std::vector{0, 11, 22, 33, 44, 55, 66, 77, 88};
+        obj()->ints.swap(0, 8);
+        auto expected = std::vector{88, 11, 22, 33, 44, 55, 66, 77, 0};
+        EXPECT_EQ(expected, obj->ints);
+    }
+
     TEST(OpDo, MoveUp)
     {
         TrackDoOp obj {};
@@ -1964,6 +1973,23 @@ namespace EditorCumulative
         EXPECT_EQ(values, obj->ints);
         obj.redoAction();
         EXPECT_EQ(expected, obj->ints);
+    }
+
+    TEST(OpUndoRedo, Swap)
+    {
+        TrackDoOp obj {};
+        const auto first = std::vector{0, 11, 22, 33, 44, 55, 66, 77, 88};
+        obj()->ints = first;
+        EXPECT_EQ(first, obj->ints);
+
+        obj()->ints.swap(0, 8);
+        const auto second = std::vector{88, 11, 22, 33, 44, 55, 66, 77, 0};
+        EXPECT_EQ(second, obj->ints);
+
+        obj.undoAction();
+        EXPECT_EQ(first, obj->ints);
+        obj.redoAction();
+        EXPECT_EQ(second, obj->ints);
     }
 
     TEST(OpUndoRedo, MoveUp)
@@ -3208,6 +3234,30 @@ namespace EditorCumulative
         obj.redoAction();
         EXPECT_EQ(expected, obj->ints);
         EXPECT_EQ(expectedSel, obj.view.ints.sel());
+    }
+
+    TEST(OpSelSync, Swap)
+    {
+        TrackDoOp obj {};
+        const auto first = std::vector{0, 11, 22, 33, 44, 55, 66, 77, 88};
+        const auto firstSel = std::vector<std::size_t>{0, 1, 3, 4, 7, 8};
+        obj()->ints = first;
+        obj()->ints.select(firstSel);
+        EXPECT_EQ(first, obj->ints);
+        EXPECT_EQ(firstSel, obj.view.ints.sel());
+
+        obj()->ints.swap(0, 8);
+        const auto second = std::vector{88, 11, 22, 33, 44, 55, 66, 77, 0};
+        const auto secondSel = std::vector<std::size_t>{8, 1, 3, 4, 7, 0};
+        EXPECT_EQ(second, obj->ints);
+        EXPECT_EQ(secondSel, obj.view.ints.sel());
+
+        obj.undoAction();
+        EXPECT_EQ(first, obj->ints);
+        EXPECT_EQ(firstSel, obj.view.ints.sel());
+        obj.redoAction();
+        EXPECT_EQ(second, obj->ints);
+        EXPECT_EQ(secondSel, obj.view.ints.sel());
     }
 
     TEST(OpSelSync, MoveUp)

--- a/RareCppTest/editor_attach_test.cpp
+++ b/RareCppTest/editor_attach_test.cpp
@@ -853,4 +853,13 @@ TEST(AttachData, MoveToL)
     EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "a");
 }
 
+TEST(AttachData, Init)
+{
+    EditData obj {};
+    obj.initData(Data {
+        .vec {0, 0, 0, 0}
+    });
+    EXPECT_EQ(4, obj.view.vec.readAttachedData().size());
+}
+
 }

--- a/RareCppTest/editor_attach_test.cpp
+++ b/RareCppTest/editor_attach_test.cpp
@@ -1,0 +1,856 @@
+#include <rarecpp/editor.h>
+#include <rarecpp/json.h>
+#include <rarecpp/reflect.h>
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <unordered_set>
+#include <vector>
+
+namespace AttachDataTest
+{
+
+using namespace RareEdit;
+
+struct Attachment
+{
+    std::string rendered;
+};
+
+struct Data
+{
+    NOTE(vec, AttachData<Attachment>)
+    std::vector<int> vec {};
+
+    REFLECT(Data, vec)
+};
+
+struct EditData : Tracked<Data, EditData>
+{
+    std::vector<int> integrityCheck {};
+    const std::vector<Attachment> & attachedData;
+
+    EditData() : Tracked{this}, attachedData(view.vec.readAttachedData()) {}
+
+    using vec_path = PATH(root->vec);
+
+    void elementAdded(vec_path, std::size_t index)
+    {
+        const char c = char(read.vec[index]) + 'a';
+        view.vec.attachedData(index).rendered = std::string(&c, 1);
+        integrityCheck.push_back(0);
+    }
+
+    void elementRemoved(vec_path, std::size_t index)
+    {
+        integrityCheck.erase(std::next(integrityCheck.begin(), static_cast<std::ptrdiff_t>(index)));
+    }
+
+    bool sizeIs(std::size_t size)
+    {
+        return read.vec.size() == size &&
+            view.vec.readAttachedData().size() == size &&
+            integrityCheck.size() == size;
+    }
+};
+
+TEST(AttachData, Reset)
+{
+    EditData obj {};
+    obj()->vec = std::vector{0, 1, 2};
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj()->vec.reset();
+    EXPECT_TRUE(obj.sizeIs(0));
+
+    obj.undoAction();
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj.redoAction();
+    EXPECT_TRUE(obj.sizeIs(0));
+}
+
+TEST(AttachData, Assign)
+{
+    EditData obj {};
+    obj()->vec = std::vector{0, 1, 2};
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj()->vec.assign(2, 3);
+    EXPECT_TRUE(obj.sizeIs(2));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "d");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "d");
+
+    obj.undoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj.redoAction();
+    EXPECT_TRUE(obj.sizeIs(2));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "d");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "d");
+}
+
+TEST(AttachData, AssignDefault)
+{
+    EditData obj {};
+    obj()->vec = std::vector{0, 1, 2};
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj()->vec.assignDefault(2);
+    EXPECT_TRUE(obj.sizeIs(2));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "a");
+
+    obj.undoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj.redoAction();
+    EXPECT_TRUE(obj.sizeIs(2));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "a");
+}
+
+TEST(AttachData, Set)
+{
+    EditData obj {};
+    obj()->vec = std::vector{0, 1, 2};
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj.undoAction();
+    EXPECT_TRUE(obj.sizeIs(0));
+
+    obj.redoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+}
+
+TEST(AttachData, Append)
+{
+    EditData obj {};
+    obj()->vec = std::vector{0, 1, 2};
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj()->vec.append(3);
+    EXPECT_TRUE(obj.sizeIs(4));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[3].rendered.c_str(), "d");
+
+    obj.undoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj.redoAction();
+    EXPECT_TRUE(obj.sizeIs(4));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[3].rendered.c_str(), "d");
+}
+
+TEST(AttachData, AppendN)
+{
+    EditData obj {};
+    obj()->vec = std::vector{0, 1, 2};
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj()->vec.append(std::vector{3, 4});
+    EXPECT_TRUE(obj.sizeIs(5));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[3].rendered.c_str(), "d");
+    EXPECT_STREQ(obj.attachedData[4].rendered.c_str(), "e");
+
+    obj.undoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj.redoAction();
+    EXPECT_TRUE(obj.sizeIs(5));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[3].rendered.c_str(), "d");
+    EXPECT_STREQ(obj.attachedData[4].rendered.c_str(), "e");
+}
+
+TEST(AttachData, Insert)
+{
+    EditData obj {};
+    obj()->vec = std::vector{0, 1, 2};
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj()->vec.insert(1, 3);
+    EXPECT_TRUE(obj.sizeIs(4));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "d");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[3].rendered.c_str(), "c");
+
+    obj.undoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj.redoAction();
+    EXPECT_TRUE(obj.sizeIs(4));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "d");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[3].rendered.c_str(), "c");
+}
+
+TEST(AttachData, InsertN)
+{
+    EditData obj {};
+    obj()->vec = std::vector{0, 1, 2};
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj()->vec.insert(1, std::vector{3, 4});
+    EXPECT_TRUE(obj.sizeIs(5));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "d");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "e");
+    EXPECT_STREQ(obj.attachedData[3].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[4].rendered.c_str(), "c");
+
+    obj.undoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj.redoAction();
+    EXPECT_TRUE(obj.sizeIs(5));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "d");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "e");
+    EXPECT_STREQ(obj.attachedData[3].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[4].rendered.c_str(), "c");
+}
+
+TEST(AttachData, Remove)
+{
+    EditData obj {};
+    obj()->vec = std::vector{0, 1, 2};
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj()->vec.remove(1);
+    EXPECT_TRUE(obj.sizeIs(2));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "c");
+
+    obj.undoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj.redoAction();
+    EXPECT_TRUE(obj.sizeIs(2));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "c");
+}
+
+TEST(AttachData, RemoveN)
+{
+    EditData obj {};
+    obj()->vec = std::vector{0, 1, 2};
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj()->vec.remove(std::vector<std::size_t>{1, 2});
+    EXPECT_TRUE(obj.sizeIs(1));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+
+    obj.undoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj.redoAction();
+    EXPECT_TRUE(obj.sizeIs(1));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+}
+
+TEST(AttachData, RemoveL)
+{
+    EditData obj {};
+    obj()->vec = std::vector{0, 1, 2};
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj()->vec.select(std::vector<std::size_t>{1, 2});
+    obj()->vec.removeSelection();
+    EXPECT_TRUE(obj.sizeIs(1));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+
+    obj.undoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj.redoAction();
+    EXPECT_TRUE(obj.sizeIs(1));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+}
+
+TEST(AttachData, Sort)
+{
+    EditData obj {};
+    obj()->vec = std::vector{2, 0, 1};
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "b");
+
+    obj()->vec.sort();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj.undoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "b");
+
+    obj.redoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+}
+
+TEST(AttachData, SortDesc)
+{
+    EditData obj {};
+    obj()->vec = std::vector{1, 0, 2};
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj()->vec.sortDesc();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "a");
+
+    obj.undoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj.redoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "a");
+}
+
+TEST(AttachData, Swap)
+{
+    EditData obj {};
+    obj()->vec = std::vector{0, 1, 2};
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj()->vec.swap(1, 2);
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "b");
+
+    obj.undoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj.redoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "b");
+}
+
+TEST(AttachData, MoveUp)
+{
+    EditData obj {};
+    obj()->vec = std::vector{0, 1, 2};
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj()->vec.moveUp(2);
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "b");
+
+    obj.undoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj.redoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "b");
+}
+
+TEST(AttachData, MoveUpN)
+{
+    EditData obj {};
+    obj()->vec = std::vector{0, 1, 2};
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj()->vec.moveUp(std::vector<std::size_t>{1, 2});
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "a");
+
+    obj.undoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj.redoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "a");
+}
+
+TEST(AttachData, MoveUpL)
+{
+    EditData obj {};
+    obj()->vec = std::vector{0, 1, 2};
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj()->vec.select(std::vector<std::size_t>{1, 2});
+    obj()->vec.moveSelectionsUp();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "a");
+
+    obj.undoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj.redoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "a");
+}
+
+TEST(AttachData, MoveTop)
+{
+    EditData obj {};
+    obj()->vec = std::vector{0, 1, 2};
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj()->vec.moveTop(1);
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj.undoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj.redoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+}
+
+TEST(AttachData, MoveTopN)
+{
+    EditData obj {};
+    obj()->vec = std::vector{0, 1, 2};
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj()->vec.moveTop(std::vector<std::size_t>{1, 2});
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "a");
+
+    obj.undoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj.redoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "a");
+}
+
+TEST(AttachData, MoveTopL)
+{
+    EditData obj {};
+    obj()->vec = std::vector{0, 1, 2};
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj()->vec.select(std::vector<std::size_t>{1, 2});
+    obj()->vec.moveSelectionsTop();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "a");
+
+    obj.undoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj.redoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "a");
+}
+
+TEST(AttachData, MoveDown)
+{
+    EditData obj {};
+    obj()->vec = std::vector{0, 1, 2};
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj()->vec.moveDown(1);
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "b");
+
+    obj.undoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj.redoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "b");
+}
+
+TEST(AttachData, MoveDownN)
+{
+    EditData obj {};
+    obj()->vec = std::vector{0, 1, 2};
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj()->vec.moveDown(std::vector<std::size_t>{0, 1});
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "b");
+
+    obj.undoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj.redoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "b");
+}
+
+TEST(AttachData, MoveDownL)
+{
+    EditData obj {};
+    obj()->vec = std::vector{0, 1, 2};
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj()->vec.select(std::vector<std::size_t>{0, 1});
+    obj()->vec.moveSelectionsDown();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "b");
+
+    obj.undoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj.redoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "b");
+}
+
+TEST(AttachData, MoveBottom)
+{
+    EditData obj {};
+    obj()->vec = std::vector{0, 1, 2};
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj()->vec.moveBottom(1);
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "b");
+
+    obj.undoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj.redoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "b");
+}
+
+TEST(AttachData, MoveBottomN)
+{
+    EditData obj {};
+    obj()->vec = std::vector{0, 1, 2};
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj()->vec.moveBottom(std::vector<std::size_t>{0, 1});
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "b");
+
+    obj.undoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj.redoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "b");
+}
+
+TEST(AttachData, MoveBottomL)
+{
+    EditData obj {};
+    obj()->vec = std::vector{0, 1, 2};
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj()->vec.select(std::vector<std::size_t>{0, 1});
+    obj()->vec.moveSelectionsBottom();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "b");
+
+    obj.undoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj.redoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "b");
+}
+
+TEST(AttachData, MoveTo)
+{
+    EditData obj {};
+    obj()->vec = std::vector{0, 1, 2};
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj()->vec.moveTo(1, 2);
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "b");
+
+    obj.undoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj.redoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "b");
+}
+
+TEST(AttachData, MoveToN)
+{
+    EditData obj {};
+    obj()->vec = std::vector{0, 1, 2};
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj()->vec.moveTo(std::vector<std::size_t>{1, 2}, 0);
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "a");
+
+    obj.undoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj.redoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "a");
+}
+
+TEST(AttachData, MoveToL)
+{
+    EditData obj {};
+    obj()->vec = std::vector{0, 1, 2};
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj()->vec.select(std::vector<std::size_t>{1, 2});
+    obj()->vec.moveSelectionsTo(0);
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "a");
+
+    obj.undoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "a");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "c");
+
+    obj.redoAction();
+    EXPECT_TRUE(obj.sizeIs(3));
+    EXPECT_STREQ(obj.attachedData[0].rendered.c_str(), "b");
+    EXPECT_STREQ(obj.attachedData[1].rendered.c_str(), "c");
+    EXPECT_STREQ(obj.attachedData[2].rendered.c_str(), "a");
+}
+
+}

--- a/RareCppTest/editor_notifications_test.cpp
+++ b/RareCppTest/editor_notifications_test.cpp
@@ -895,9 +895,9 @@ TEST(OpNtfy, Insert)
     obj()->vec.select(1);
 
     std::vector<Change> doExpected {
+        { .type = ChangeType::ElementAdded, .fieldIndex = vecFieldIndex, .index = 1 },
         { .type = ChangeType::ElementMoved, .fieldIndex = vecFieldIndex, .oldIndex = 2, .index = 3},
         { .type = ChangeType::ElementMoved, .fieldIndex = vecFieldIndex, .oldIndex = 1, .index = 2},
-        { .type = ChangeType::ElementAdded, .fieldIndex = vecFieldIndex, .index = 1 },
         { .type = ChangeType::SelectionsChanged, .fieldIndex = vecFieldIndex }
     };
     std::vector<Change> undoExpected {
@@ -927,11 +927,11 @@ TEST(OpNtfy, InsertN)
     obj()->vec.select(1);
 
     std::vector<Change> doExpected {
-        { .type = ChangeType::ElementMoved, .fieldIndex = vecFieldIndex, .oldIndex = 2, .index = 5},
-        { .type = ChangeType::ElementMoved, .fieldIndex = vecFieldIndex, .oldIndex = 1, .index = 4},
         { .type = ChangeType::ElementAdded, .fieldIndex = vecFieldIndex, .index = 1 },
         { .type = ChangeType::ElementAdded, .fieldIndex = vecFieldIndex, .index = 2 },
         { .type = ChangeType::ElementAdded, .fieldIndex = vecFieldIndex, .index = 3 },
+        { .type = ChangeType::ElementMoved, .fieldIndex = vecFieldIndex, .oldIndex = 2, .index = 5},
+        { .type = ChangeType::ElementMoved, .fieldIndex = vecFieldIndex, .oldIndex = 1, .index = 4},
         { .type = ChangeType::SelectionsChanged, .fieldIndex = vecFieldIndex }
     };
     std::vector<Change> undoExpected {
@@ -969,9 +969,9 @@ TEST(OpNtfy, Remove)
         { .type = ChangeType::SelectionsChanged, .fieldIndex = vecFieldIndex }
     };
     std::vector<Change> undoExpected {
+        { .type = ChangeType::ElementAdded, .fieldIndex = vecFieldIndex, .index = 1 },
         { .type = ChangeType::ElementMoved, .fieldIndex = vecFieldIndex, .oldIndex = 2, .index = 3},
         { .type = ChangeType::ElementMoved, .fieldIndex = vecFieldIndex, .oldIndex = 1, .index = 2},
-        { .type = ChangeType::ElementAdded, .fieldIndex = vecFieldIndex, .index = 1 },
         { .type = ChangeType::SelectionsChanged, .fieldIndex = vecFieldIndex }
     };
 
@@ -1002,10 +1002,10 @@ TEST(OpNtfy, RemoveN)
         { .type = ChangeType::SelectionsChanged, .fieldIndex = vecFieldIndex }
     };
     std::vector<Change> undoExpected {
-        { .type = ChangeType::ElementMoved, .fieldIndex = vecFieldIndex, .oldIndex = 2, .index = 4},
-        { .type = ChangeType::ElementMoved, .fieldIndex = vecFieldIndex, .oldIndex = 1, .index = 3},
         { .type = ChangeType::ElementAdded, .fieldIndex = vecFieldIndex, .index = 1 },
         { .type = ChangeType::ElementAdded, .fieldIndex = vecFieldIndex, .index = 2 },
+        { .type = ChangeType::ElementMoved, .fieldIndex = vecFieldIndex, .oldIndex = 2, .index = 4},
+        { .type = ChangeType::ElementMoved, .fieldIndex = vecFieldIndex, .oldIndex = 1, .index = 3},
         { .type = ChangeType::SelectionsChanged, .fieldIndex = vecFieldIndex }
     };
 
@@ -1036,10 +1036,10 @@ TEST(OpNtfy, RemoveL)
         { .type = ChangeType::SelectionsChanged, .fieldIndex = vecFieldIndex }
     };
     std::vector<Change> undoExpected {
-        { .type = ChangeType::ElementMoved, .fieldIndex = vecFieldIndex, .oldIndex = 2, .index = 4},
-        { .type = ChangeType::ElementMoved, .fieldIndex = vecFieldIndex, .oldIndex = 1, .index = 3},
         { .type = ChangeType::ElementAdded, .fieldIndex = vecFieldIndex, .index = 1 },
         { .type = ChangeType::ElementAdded, .fieldIndex = vecFieldIndex, .index = 2 },
+        { .type = ChangeType::ElementMoved, .fieldIndex = vecFieldIndex, .oldIndex = 2, .index = 4},
+        { .type = ChangeType::ElementMoved, .fieldIndex = vecFieldIndex, .oldIndex = 1, .index = 3},
         { .type = ChangeType::SelectionsChanged, .fieldIndex = vecFieldIndex }
     };
 

--- a/RareCppTest/editor_notifications_test.cpp
+++ b/RareCppTest/editor_notifications_test.cpp
@@ -946,6 +946,36 @@ TEST(OpNtfy, SortDesc)
     EXPECT_EQ(doExpected, obj.changes);
 }
 
+TEST(OpNtfy, Swap)
+{
+    Obj obj {};
+    obj()->vec = std::vector{4, 5, 6};
+    obj()->vec.select(0);
+
+    std::vector<Change> doExpected {
+        { .type = ChangeType::ElementMoved, .fieldIndex = vecFieldIndex, .oldIndex = 0, .index = 2 },
+        { .type = ChangeType::ElementMoved, .fieldIndex = vecFieldIndex, .oldIndex = 2, .index = 0 },
+        { .type = ChangeType::SelectionsChanged, .fieldIndex = vecFieldIndex }
+    };
+    std::vector<Change> undoExpected {
+        { .type = ChangeType::ElementMoved, .fieldIndex = vecFieldIndex, .oldIndex = 2, .index = 0 },
+        { .type = ChangeType::ElementMoved, .fieldIndex = vecFieldIndex, .oldIndex = 0, .index = 2 },
+        { .type = ChangeType::SelectionsChanged, .fieldIndex = vecFieldIndex }
+    };
+
+    obj.changes.clear();
+    obj()->vec.swap(0, 2);
+    EXPECT_EQ(doExpected, obj.changes);
+
+    obj.changes.clear();
+    obj.undoAction();
+    EXPECT_EQ(undoExpected, obj.changes);
+
+    obj.changes.clear();
+    obj.redoAction();
+    EXPECT_EQ(doExpected, obj.changes);
+}
+
 TEST(OpNtfy, MoveUp)
 {
     Obj obj {};

--- a/RareCppTest/editor_notifications_test.cpp
+++ b/RareCppTest/editor_notifications_test.cpp
@@ -634,6 +634,206 @@ TEST(OpNtfy, SetL)
     EXPECT_EQ(doExpected, obj.changes);
 }
 
+TEST(OpNtfy, PlusEq)
+{
+    Obj obj {};
+    obj()->primitive = 2;
+    EXPECT_EQ(obj->primitive, 2);
+    
+    std::vector<Change> doExpected { {.type = ChangeType::ValueChanged, .fieldIndex = primitiveFieldIndex, .oldValue = 2, .value = 5} };
+    std::vector<Change> undoExpected { {.type = ChangeType::ValueChanged, .fieldIndex = primitiveFieldIndex, .oldValue = 5, .value = 2} };
+    
+    obj.changes.clear();
+    obj()->primitive += 3;
+    EXPECT_EQ(obj->primitive, 5);
+    EXPECT_EQ(doExpected, obj.changes);
+    
+    obj.changes.clear();
+    obj.undoAction();
+    EXPECT_EQ(obj->primitive, 2);
+    EXPECT_EQ(undoExpected, obj.changes);
+    
+    obj.changes.clear();
+    obj.redoAction();
+    EXPECT_EQ(obj->primitive, 5);
+    EXPECT_EQ(doExpected, obj.changes);
+}
+
+TEST(OpNtfy, MinusEq)
+{
+    Obj obj {};
+    obj()->primitive = 7;
+    EXPECT_EQ(obj->primitive, 7);
+    
+    std::vector<Change> doExpected { {.type = ChangeType::ValueChanged, .fieldIndex = primitiveFieldIndex, .oldValue = 7, .value = 5} };
+    std::vector<Change> undoExpected { {.type = ChangeType::ValueChanged, .fieldIndex = primitiveFieldIndex, .oldValue = 5, .value = 7} };
+    
+    obj.changes.clear();
+    obj()->primitive -= 2;
+    EXPECT_EQ(obj->primitive, 5);
+    EXPECT_EQ(doExpected, obj.changes);
+    
+    obj.changes.clear();
+    obj.undoAction();
+    EXPECT_EQ(obj->primitive, 7);
+    EXPECT_EQ(undoExpected, obj.changes);
+    
+    obj.changes.clear();
+    obj.redoAction();
+    EXPECT_EQ(obj->primitive, 5);
+    EXPECT_EQ(doExpected, obj.changes);
+}
+
+TEST(OpNtfy, MultEq)
+{
+    Obj obj {};
+    obj()->primitive = 2;
+    EXPECT_EQ(obj->primitive, 2);
+    
+    std::vector<Change> doExpected { {.type = ChangeType::ValueChanged, .fieldIndex = primitiveFieldIndex, .oldValue = 2, .value = 4} };
+    std::vector<Change> undoExpected { {.type = ChangeType::ValueChanged, .fieldIndex = primitiveFieldIndex, .oldValue = 4, .value = 2} };
+    
+    obj.changes.clear();
+    obj()->primitive *= 2;
+    EXPECT_EQ(obj->primitive, 4);
+    EXPECT_EQ(doExpected, obj.changes);
+    
+    obj.changes.clear();
+    obj.undoAction();
+    EXPECT_EQ(obj->primitive, 2);
+    EXPECT_EQ(undoExpected, obj.changes);
+    
+    obj.changes.clear();
+    obj.redoAction();
+    EXPECT_EQ(obj->primitive, 4);
+    EXPECT_EQ(doExpected, obj.changes);
+}
+
+TEST(OpNtfy, DivEq)
+{
+    Obj obj {};
+    obj()->primitive = 4;
+    EXPECT_EQ(obj->primitive, 4);
+    
+    std::vector<Change> doExpected { {.type = ChangeType::ValueChanged, .fieldIndex = primitiveFieldIndex, .oldValue = 4, .value = 2} };
+    std::vector<Change> undoExpected { {.type = ChangeType::ValueChanged, .fieldIndex = primitiveFieldIndex, .oldValue = 2, .value = 4} };
+    
+    obj.changes.clear();
+    obj()->primitive /= 2;
+    EXPECT_EQ(obj->primitive, 2);
+    EXPECT_EQ(doExpected, obj.changes);
+    
+    obj.changes.clear();
+    obj.undoAction();
+    EXPECT_EQ(obj->primitive, 4);
+    EXPECT_EQ(undoExpected, obj.changes);
+    
+    obj.changes.clear();
+    obj.redoAction();
+    EXPECT_EQ(obj->primitive, 2);
+    EXPECT_EQ(doExpected, obj.changes);
+}
+
+TEST(OpNtfy, ModEq)
+{
+    Obj obj {};
+    obj()->primitive = 5;
+    EXPECT_EQ(obj->primitive, 5);
+    
+    std::vector<Change> doExpected { {.type = ChangeType::ValueChanged, .fieldIndex = primitiveFieldIndex, .oldValue = 5, .value = 1} };
+    std::vector<Change> undoExpected { {.type = ChangeType::ValueChanged, .fieldIndex = primitiveFieldIndex, .oldValue = 1, .value = 5} };
+    
+    obj.changes.clear();
+    obj()->primitive %= 2;
+    EXPECT_EQ(obj->primitive, 1);
+    EXPECT_EQ(doExpected, obj.changes);
+    
+    obj.changes.clear();
+    obj.undoAction();
+    EXPECT_EQ(obj->primitive, 5);
+    EXPECT_EQ(undoExpected, obj.changes);
+    
+    obj.changes.clear();
+    obj.redoAction();
+    EXPECT_EQ(obj->primitive, 1);
+    EXPECT_EQ(doExpected, obj.changes);
+}
+
+TEST(OpNtfy, XorEq)
+{
+    Obj obj {};
+    obj()->primitive = 0b01;
+    EXPECT_EQ(obj->primitive, 0b01);
+    
+    std::vector<Change> doExpected { {.type = ChangeType::ValueChanged, .fieldIndex = primitiveFieldIndex, .oldValue = 0b01, .value = 0b10} };
+    std::vector<Change> undoExpected { {.type = ChangeType::ValueChanged, .fieldIndex = primitiveFieldIndex, .oldValue = 0b10, .value = 0b01} };
+    
+    obj.changes.clear();
+    obj()->primitive ^= 0b11;
+    EXPECT_EQ(obj->primitive, 0b10);
+    EXPECT_EQ(doExpected, obj.changes);
+    
+    obj.changes.clear();
+    obj.undoAction();
+    EXPECT_EQ(obj->primitive, 0b01);
+    EXPECT_EQ(undoExpected, obj.changes);
+    
+    obj.changes.clear();
+    obj.redoAction();
+    EXPECT_EQ(obj->primitive, 0b10);
+    EXPECT_EQ(doExpected, obj.changes);
+}
+
+TEST(OpNtfy, AndEq)
+{
+    Obj obj {};
+    obj()->primitive = 0b101;
+    EXPECT_EQ(obj->primitive, 0b101);
+    
+    std::vector<Change> doExpected { {.type = ChangeType::ValueChanged, .fieldIndex = primitiveFieldIndex, .oldValue = 0b101, .value = 0b001} };
+    std::vector<Change> undoExpected { {.type = ChangeType::ValueChanged, .fieldIndex = primitiveFieldIndex, .oldValue = 0b001, .value = 0b101} };
+    
+    obj.changes.clear();
+    obj()->primitive &= 0b011;
+    EXPECT_EQ(obj->primitive, 0b001);
+    EXPECT_EQ(doExpected, obj.changes);
+    
+    obj.changes.clear();
+    obj.undoAction();
+    EXPECT_EQ(obj->primitive, 0b101);
+    EXPECT_EQ(undoExpected, obj.changes);
+    
+    obj.changes.clear();
+    obj.redoAction();
+    EXPECT_EQ(obj->primitive, 0b001);
+    EXPECT_EQ(doExpected, obj.changes);
+}
+
+TEST(OpNtfy, OrEq)
+{
+    Obj obj {};
+    obj()->primitive = 0b00;
+    EXPECT_EQ(obj->primitive, 0b00);
+    
+    std::vector<Change> doExpected { {.type = ChangeType::ValueChanged, .fieldIndex = primitiveFieldIndex, .oldValue = 0b00, .value = 0b11} };
+    std::vector<Change> undoExpected { {.type = ChangeType::ValueChanged, .fieldIndex = primitiveFieldIndex, .oldValue = 0b11, .value = 0b00} };
+    
+    obj.changes.clear();
+    obj()->primitive |= 0b11;
+    EXPECT_EQ(obj->primitive, 0b11);
+    EXPECT_EQ(doExpected, obj.changes);
+    
+    obj.changes.clear();
+    obj.undoAction();
+    EXPECT_EQ(obj->primitive, 0b00);
+    EXPECT_EQ(undoExpected, obj.changes);
+    
+    obj.changes.clear();
+    obj.redoAction();
+    EXPECT_EQ(obj->primitive, 0b11);
+    EXPECT_EQ(doExpected, obj.changes);
+}
+
 TEST(OpNtfy, Append)
 {
     Obj obj {};
@@ -1747,6 +1947,32 @@ TEST(OpNtfy, MoveToL)
     obj.changes.clear();
     obj.redoAction();
     EXPECT_EQ(doExpected, obj.changes);
+}
+
+struct NotifyAfterActionTest
+{
+    int a = 0;
+
+    REFLECT(NotifyAfterActionTest, a)
+};
+
+struct EditNotifyAfterActionTest : RareEdit::Tracked<NotifyAfterActionTest, EditNotifyAfterActionTest>
+{
+    EditNotifyAfterActionTest() : Tracked{this} {}
+
+    std::vector<std::size_t> afterActionIndexes {};
+    
+    void afterAction(std::size_t actionIndex) { afterActionIndexes.push_back(actionIndex); }
+};
+
+TEST(NotifyMisc, NotifyAfterAction)
+{
+    EditNotifyAfterActionTest myObj {};
+    myObj()->a = 1;
+    EXPECT_EQ(myObj.afterActionIndexes, std::vector<std::size_t>{0});
+    myObj()->a = 2;
+    auto expectedActionIndexes = std::vector<std::size_t>{0, 1};
+    EXPECT_EQ(myObj.afterActionIndexes, expectedActionIndexes);
 }
 
 } // namespace NtfyTest

--- a/RareCppTest/flat_mdspan_test.cpp
+++ b/RareCppTest/flat_mdspan_test.cpp
@@ -1,0 +1,567 @@
+#include <rarecpp/editor.h>
+#include <gtest/gtest.h>
+
+namespace FlatMdspanTest
+{
+
+using namespace RareEdit;
+
+TEST(FlatMdspan, ArrayHeader)
+{
+    int oneD[2] {22, 33};
+    EXPECT_EQ(array_header(oneD)[0], 22);
+    int twoD[3][2] {{33, 44}, {55, 66}, {77, 88}};
+    EXPECT_EQ(array_header(twoD)[0], 33);
+    int threeD[3][2][1] {{{44}, {55}}, {{66}, {77}}, {{88}, {99}}};
+    EXPECT_EQ(array_header(threeD)[0], 44);
+    int fourD[2][3][2][1] {{{{55}, {66}}, {{77}, {88}}, {{89}, {90}}}, {{{56}, {67}}, {{78}, {89}}, {{90}, {91}}}};
+    EXPECT_EQ(array_header(fourD)[0], 55);
+}
+
+TEST(FlatMdspan, OneD)
+{
+    int oneD[2] {22, 33};
+    auto span = as_1d(oneD);
+    const auto & constSpan = span;
+    using Flatspan = decltype(span);
+    bool isSame = std::is_same_v<Flatspan, flat_mdspan<int, 2>>;
+    EXPECT_TRUE(isSame);
+    isSame = std::is_same_v<Flatspan::element_type, int>;
+    EXPECT_TRUE(isSame);
+    isSame = std::is_same_v<Flatspan::extents, std::index_sequence<2>>;
+    EXPECT_TRUE(isSame);
+    EXPECT_EQ(Flatspan::rank, 1);
+    EXPECT_EQ(Flatspan::size, 2);
+    EXPECT_EQ(span[0], 22);
+    EXPECT_EQ(span[1], 33);
+    EXPECT_EQ(constSpan[0], 22);
+    EXPECT_EQ(constSpan[1], 33);
+    for ( int & i : span ) // Non-const iterators
+        ++i;
+    EXPECT_EQ(oneD[0], 23);
+    EXPECT_EQ(oneD[1], 34);
+    EXPECT_EQ(span[0], 23);
+    EXPECT_EQ(span[1], 34);
+    EXPECT_EQ(constSpan[0], 23);
+    EXPECT_EQ(constSpan[1], 34);
+    std::size_t index = 0;
+    for ( auto & i : constSpan ) // Const iterator
+    {
+        EXPECT_EQ(oneD[index], i);
+        ++index;
+    }
+    EXPECT_EQ(index, 2);
+    for ( auto it = span.flatBegin(); it != span.flatEnd(); ++it ) // Non-const flat it
+        ++(*it);
+    EXPECT_EQ(oneD[0], 24);
+    EXPECT_EQ(oneD[1], 35);
+    EXPECT_EQ(span[0], 24);
+    EXPECT_EQ(span[1], 35);
+    EXPECT_EQ(constSpan[0], 24);
+    EXPECT_EQ(constSpan[1], 35);
+    index = 0;
+    for ( auto it = constSpan.flatBegin(); it != constSpan.flatEnd(); ++it ) // Const flat it
+    {
+        bool isConst = std::is_const_v<std::remove_reference_t<decltype(*it)>>;
+        EXPECT_TRUE(isConst);
+        EXPECT_EQ(oneD[index], *it);
+        ++index;
+    }
+    EXPECT_EQ(index, 2);
+
+    int other[2] {66, 77};
+    span = as_1d(other);
+    EXPECT_EQ(oneD[0], 66);
+    EXPECT_EQ(oneD[1], 77);
+
+    span.clear();
+    EXPECT_EQ(oneD[0], 0);
+    EXPECT_EQ(oneD[1], 0);
+
+    span.fill(11);
+    EXPECT_EQ(oneD[0], 11);
+    EXPECT_EQ(oneD[1], 11);
+
+    oneD[1] = 22;
+    span.swap(as_1d(other));
+    EXPECT_EQ(oneD[0], 66);
+    EXPECT_EQ(oneD[1], 77);
+    EXPECT_EQ(other[0], 11);
+    EXPECT_EQ(other[1], 22);
+    
+    EXPECT_TRUE(is_flat_mdspan<Flatspan>::value);
+    EXPECT_TRUE(is_flat_mdspan<const Flatspan>::value);
+    EXPECT_TRUE(is_flat_mdspan_v<Flatspan>);
+    EXPECT_TRUE(is_flat_mdspan_v<const Flatspan>);
+    EXPECT_FALSE(is_flat_mdspan<decltype(oneD)>::value);
+    EXPECT_FALSE(is_flat_mdspan<decltype(oneD)>::value);
+}
+
+TEST(FlatMdspan, TwoD)
+{
+    // [y][x], ++x steps a true distance of 1, ++y steps a true distance of width
+    int twoD[3][2] {{33, 44}, {55, 66}, {77, 88}};
+    auto span = as_1d(twoD);
+    const auto & constSpan = span;
+    using Flatspan = decltype(span);
+    bool isSame = std::is_same_v<Flatspan, flat_mdspan<int, 3, 2>>;
+    EXPECT_TRUE(isSame);
+    isSame = std::is_same_v<Flatspan::element_type, int>;
+    EXPECT_TRUE(isSame);
+    isSame = std::is_same_v<Flatspan::extents, std::index_sequence<3, 2>>;
+    EXPECT_TRUE(isSame);
+    EXPECT_EQ(Flatspan::rank, 2);
+    EXPECT_EQ(Flatspan::size, 6);
+    EXPECT_EQ(span[0][0], 33);
+    EXPECT_EQ(span[0][1], 44);
+    EXPECT_EQ(span[1][0], 55);
+    EXPECT_EQ(span[1][1], 66);
+    EXPECT_EQ(span[2][0], 77);
+    EXPECT_EQ(span[2][1], 88);
+    EXPECT_EQ(constSpan[0][0], 33);
+    EXPECT_EQ(constSpan[0][1], 44);
+    EXPECT_EQ(constSpan[1][0], 55);
+    EXPECT_EQ(constSpan[1][1], 66);
+    EXPECT_EQ(constSpan[2][0], 77);
+    EXPECT_EQ(constSpan[2][1], 88);
+    for ( auto row : span ) // Non-const iterators
+    {
+        for ( int & i : row )
+            ++i;
+    }
+    EXPECT_EQ(twoD[0][0], 34);
+    EXPECT_EQ(twoD[0][1], 45);
+    EXPECT_EQ(twoD[1][0], 56);
+    EXPECT_EQ(twoD[1][1], 67);
+    EXPECT_EQ(twoD[2][0], 78);
+    EXPECT_EQ(twoD[2][1], 89);
+    EXPECT_EQ(span[0][0], 34);
+    EXPECT_EQ(span[0][1], 45);
+    EXPECT_EQ(span[1][0], 56);
+    EXPECT_EQ(span[1][1], 67);
+    EXPECT_EQ(span[2][0], 78);
+    EXPECT_EQ(span[2][1], 89);
+    EXPECT_EQ(constSpan[0][0], 34);
+    EXPECT_EQ(constSpan[0][1], 45);
+    EXPECT_EQ(constSpan[1][0], 56);
+    EXPECT_EQ(constSpan[1][1], 67);
+    EXPECT_EQ(constSpan[2][0], 78);
+    EXPECT_EQ(constSpan[2][1], 89);
+    std::size_t y = 0;
+    for ( auto row : constSpan ) // Const iterator
+    {
+        std::size_t x = 0;
+        for ( auto & i : row )
+        {
+            EXPECT_EQ(twoD[y][x], i);
+            ++x;
+        }
+        EXPECT_EQ(x, 2);
+        ++y;
+    }
+    EXPECT_EQ(y, 3);
+    for ( auto it = span.flatBegin(); it != span.flatEnd(); ++it ) // Non-const flat it
+        ++(*it);
+    EXPECT_EQ(twoD[0][0], 35);
+    EXPECT_EQ(twoD[0][1], 46);
+    EXPECT_EQ(twoD[1][0], 57);
+    EXPECT_EQ(twoD[1][1], 68);
+    EXPECT_EQ(twoD[2][0], 79);
+    EXPECT_EQ(twoD[2][1], 90);
+    EXPECT_EQ(span[0][0], 35);
+    EXPECT_EQ(span[0][1], 46);
+    EXPECT_EQ(span[1][0], 57);
+    EXPECT_EQ(span[1][1], 68);
+    EXPECT_EQ(span[2][0], 79);
+    EXPECT_EQ(span[2][1], 90);
+    EXPECT_EQ(constSpan[0][0], 35);
+    EXPECT_EQ(constSpan[0][1], 46);
+    EXPECT_EQ(constSpan[1][0], 57);
+    EXPECT_EQ(constSpan[1][1], 68);
+    EXPECT_EQ(constSpan[2][0], 79);
+    EXPECT_EQ(constSpan[2][1], 90);
+    std::size_t index = 0;
+    for ( auto it = constSpan.flatBegin(); it != constSpan.flatEnd(); ++it ) // Const flat it
+    {
+        bool isConst = std::is_const_v<std::remove_reference_t<decltype(*it)>>;
+        EXPECT_TRUE(isConst);
+        EXPECT_EQ((&twoD[0][0])[index], *it);
+        ++index;
+    }
+    EXPECT_EQ(index, 6);
+
+    int other[3][2] {{22, 33}, {44, 55}, {66, 77}};
+    span = as_1d(other);
+    EXPECT_EQ(twoD[0][0], 22);
+    EXPECT_EQ(twoD[0][1], 33);
+    EXPECT_EQ(twoD[1][0], 44);
+    EXPECT_EQ(twoD[1][1], 55);
+    EXPECT_EQ(twoD[2][0], 66);
+    EXPECT_EQ(twoD[2][1], 77);
+
+    span.clear();
+    EXPECT_EQ(twoD[0][0], 0);
+    EXPECT_EQ(twoD[0][1], 0);
+    EXPECT_EQ(twoD[1][0], 0);
+    EXPECT_EQ(twoD[1][1], 0);
+    EXPECT_EQ(twoD[2][0], 0);
+    EXPECT_EQ(twoD[2][1], 0);
+
+    span.fill(11);
+    EXPECT_EQ(twoD[0][0], 11);
+    EXPECT_EQ(twoD[0][1], 11);
+    EXPECT_EQ(twoD[1][0], 11);
+    EXPECT_EQ(twoD[1][1], 11);
+    EXPECT_EQ(twoD[2][0], 11);
+    EXPECT_EQ(twoD[2][1], 11);
+
+    twoD[0][1] = 22;
+    twoD[1][0] = 33;
+    twoD[1][1] = 44;
+    twoD[2][0] = 55;
+    twoD[2][1] = 66; // 11, 22, 33, 44, 55, 66
+    span.swap(as_1d(other)); // 22, 33, 44, 55, 66, 77
+    EXPECT_EQ(twoD[0][0], 22);
+    EXPECT_EQ(twoD[0][1], 33);
+    EXPECT_EQ(twoD[1][0], 44);
+    EXPECT_EQ(twoD[1][1], 55);
+    EXPECT_EQ(twoD[2][0], 66);
+    EXPECT_EQ(twoD[2][1], 77);
+    EXPECT_EQ(other[0][0], 11);
+    EXPECT_EQ(other[0][1], 22);
+    EXPECT_EQ(other[1][0], 33);
+    EXPECT_EQ(other[1][1], 44);
+    EXPECT_EQ(other[2][0], 55);
+    EXPECT_EQ(other[2][1], 66);
+    
+    EXPECT_TRUE(is_flat_mdspan<Flatspan>::value);
+    EXPECT_TRUE(is_flat_mdspan<const Flatspan>::value);
+    EXPECT_TRUE(is_flat_mdspan_v<Flatspan>);
+    EXPECT_TRUE(is_flat_mdspan_v<const Flatspan>);
+    EXPECT_FALSE(is_flat_mdspan<decltype(twoD)>::value);
+    EXPECT_FALSE(is_flat_mdspan<decltype(twoD)>::value);
+}
+
+
+TEST(FlatMdspan, ThreeD)
+{
+    // [z][y][x], ++x steps a true distance of 1, ++y steps a true distance of width, ++z steps a true distance of height*width
+    int threeD[4][3][2] {
+        {{33, 44}, {55, 66}, {77, 88}},
+        {{333, 444}, {555, 666}, {777, 888}},
+        {{3333, 4444}, {5555, 6666}, {7777, 8888}},
+        {{33333, 44444}, {55555, 66666}, {77777, 88888}}
+    };
+    auto span = as_1d(threeD);
+    const auto & constSpan = span;
+    using Flatspan = decltype(span);
+    bool isSame = std::is_same_v<Flatspan, flat_mdspan<int, 4, 3, 2>>;
+    EXPECT_TRUE(isSame);
+    isSame = std::is_same_v<Flatspan::element_type, int>;
+    EXPECT_TRUE(isSame);
+    isSame = std::is_same_v<Flatspan::extents, std::index_sequence<4, 3, 2>>;
+    EXPECT_TRUE(isSame);
+    EXPECT_EQ(Flatspan::rank, 3);
+    EXPECT_EQ(Flatspan::size, 24);
+    EXPECT_EQ(span[0][0][0], 33);
+    EXPECT_EQ(span[0][0][1], 44);
+    EXPECT_EQ(span[0][1][0], 55);
+    EXPECT_EQ(span[0][1][1], 66);
+    EXPECT_EQ(span[0][2][0], 77);
+    EXPECT_EQ(span[0][2][1], 88);
+    EXPECT_EQ(span[1][0][0], 333);
+    EXPECT_EQ(span[1][0][1], 444);
+    EXPECT_EQ(span[1][1][0], 555);
+    EXPECT_EQ(span[1][1][1], 666);
+    EXPECT_EQ(span[1][2][0], 777);
+    EXPECT_EQ(span[1][2][1], 888);
+    EXPECT_EQ(span[2][0][0], 3333);
+    EXPECT_EQ(span[2][0][1], 4444);
+    EXPECT_EQ(span[2][1][0], 5555);
+    EXPECT_EQ(span[2][1][1], 6666);
+    EXPECT_EQ(span[2][2][0], 7777);
+    EXPECT_EQ(span[2][2][1], 8888);
+    EXPECT_EQ(span[3][0][0], 33333);
+    EXPECT_EQ(span[3][0][1], 44444);
+    EXPECT_EQ(span[3][1][0], 55555);
+    EXPECT_EQ(span[3][1][1], 66666);
+    EXPECT_EQ(span[3][2][0], 77777);
+    EXPECT_EQ(span[3][2][1], 88888);
+    EXPECT_EQ(constSpan[0][0][0], 33);
+    EXPECT_EQ(constSpan[0][0][1], 44);
+    EXPECT_EQ(constSpan[0][1][0], 55);
+    EXPECT_EQ(constSpan[0][1][1], 66);
+    EXPECT_EQ(constSpan[0][2][0], 77);
+    EXPECT_EQ(constSpan[0][2][1], 88);
+    EXPECT_EQ(constSpan[1][0][0], 333);
+    EXPECT_EQ(constSpan[1][0][1], 444);
+    EXPECT_EQ(constSpan[1][1][0], 555);
+    EXPECT_EQ(constSpan[1][1][1], 666);
+    EXPECT_EQ(constSpan[1][2][0], 777);
+    EXPECT_EQ(constSpan[1][2][1], 888);
+    EXPECT_EQ(constSpan[2][0][0], 3333);
+    EXPECT_EQ(constSpan[2][0][1], 4444);
+    EXPECT_EQ(constSpan[2][1][0], 5555);
+    EXPECT_EQ(constSpan[2][1][1], 6666);
+    EXPECT_EQ(constSpan[2][2][0], 7777);
+    EXPECT_EQ(constSpan[2][2][1], 8888);
+    EXPECT_EQ(constSpan[3][0][0], 33333);
+    EXPECT_EQ(constSpan[3][0][1], 44444);
+    EXPECT_EQ(constSpan[3][1][0], 55555);
+    EXPECT_EQ(constSpan[3][1][1], 66666);
+    EXPECT_EQ(constSpan[3][2][0], 77777);
+    EXPECT_EQ(constSpan[3][2][1], 88888);
+    for ( auto slice : span ) // Non-const iterators
+    {
+        for ( auto row : slice )
+        {
+            for ( int & i : row )
+                ++i;
+        }
+    }
+    EXPECT_EQ(threeD[0][0][0], 34);
+    EXPECT_EQ(threeD[0][0][1], 45);
+    EXPECT_EQ(threeD[0][1][0], 56);
+    EXPECT_EQ(threeD[0][1][1], 67);
+    EXPECT_EQ(threeD[0][2][0], 78);
+    EXPECT_EQ(threeD[0][2][1], 89);
+    EXPECT_EQ(threeD[1][0][0], 334);
+    EXPECT_EQ(threeD[1][0][1], 445);
+    EXPECT_EQ(threeD[1][1][0], 556);
+    EXPECT_EQ(threeD[1][1][1], 667);
+    EXPECT_EQ(threeD[1][2][0], 778);
+    EXPECT_EQ(threeD[1][2][1], 889);
+    EXPECT_EQ(threeD[2][0][0], 3334);
+    EXPECT_EQ(threeD[2][0][1], 4445);
+    EXPECT_EQ(threeD[2][1][0], 5556);
+    EXPECT_EQ(threeD[2][1][1], 6667);
+    EXPECT_EQ(threeD[2][2][0], 7778);
+    EXPECT_EQ(threeD[2][2][1], 8889);
+    EXPECT_EQ(threeD[3][0][0], 33334);
+    EXPECT_EQ(threeD[3][0][1], 44445);
+    EXPECT_EQ(threeD[3][1][0], 55556);
+    EXPECT_EQ(threeD[3][1][1], 66667);
+    EXPECT_EQ(threeD[3][2][0], 77778);
+    EXPECT_EQ(threeD[3][2][1], 88889);
+    std::size_t z = 0;
+    for ( auto slice : constSpan ) // Const iterator
+    {
+        std::size_t y = 0;
+        for ( auto row : slice )
+        {
+            std::size_t x = 0;
+            for ( auto & i : row )
+            {
+                EXPECT_EQ(threeD[z][y][x], i);
+                ++x;
+            }
+            EXPECT_EQ(x, 2);
+            ++y;
+        }
+        EXPECT_EQ(y, 3);
+        ++z;
+    }
+    EXPECT_EQ(z, 4);
+    for ( auto it = span.flatBegin(); it != span.flatEnd(); ++it ) // Non-const flat it
+        ++(*it);
+    EXPECT_EQ(threeD[0][0][0], 35);
+    EXPECT_EQ(threeD[0][0][1], 46);
+    EXPECT_EQ(threeD[0][1][0], 57);
+    EXPECT_EQ(threeD[0][1][1], 68);
+    EXPECT_EQ(threeD[0][2][0], 79);
+    EXPECT_EQ(threeD[0][2][1], 90);
+    EXPECT_EQ(threeD[1][0][0], 335);
+    EXPECT_EQ(threeD[1][0][1], 446);
+    EXPECT_EQ(threeD[1][1][0], 557);
+    EXPECT_EQ(threeD[1][1][1], 668);
+    EXPECT_EQ(threeD[1][2][0], 779);
+    EXPECT_EQ(threeD[1][2][1], 890);
+    EXPECT_EQ(threeD[2][0][0], 3335);
+    EXPECT_EQ(threeD[2][0][1], 4446);
+    EXPECT_EQ(threeD[2][1][0], 5557);
+    EXPECT_EQ(threeD[2][1][1], 6668);
+    EXPECT_EQ(threeD[2][2][0], 7779);
+    EXPECT_EQ(threeD[2][2][1], 8890);
+    EXPECT_EQ(threeD[3][0][0], 33335);
+    EXPECT_EQ(threeD[3][0][1], 44446);
+    EXPECT_EQ(threeD[3][1][0], 55557);
+    EXPECT_EQ(threeD[3][1][1], 66668);
+    EXPECT_EQ(threeD[3][2][0], 77779);
+    EXPECT_EQ(threeD[3][2][1], 88890);
+    std::size_t index = 0;
+    for ( auto it = constSpan.flatBegin(); it != constSpan.flatEnd(); ++it ) // Const flat it
+    {
+        bool isConst = std::is_const_v<std::remove_reference_t<decltype(*it)>>;
+        EXPECT_TRUE(isConst);
+        EXPECT_EQ((&threeD[0][0][0])[index], *it);
+        ++index;
+    }
+    EXPECT_EQ(index, 24);
+
+    int other[4][3][2] {
+        {{22, 33}, {44, 55}, {66, 77}},
+        {{222, 333}, {444, 555}, {666, 777}},
+        {{2222, 3333}, {4444, 5555}, {6666, 7777}},
+        {{22222, 33333}, {44444, 55555}, {66666, 77777}}
+    };
+    span = as_1d(other);
+    EXPECT_EQ(threeD[0][0][0], 22);
+    EXPECT_EQ(threeD[0][0][1], 33);
+    EXPECT_EQ(threeD[0][1][0], 44);
+    EXPECT_EQ(threeD[0][1][1], 55);
+    EXPECT_EQ(threeD[0][2][0], 66);
+    EXPECT_EQ(threeD[0][2][1], 77);
+    EXPECT_EQ(threeD[1][0][0], 222);
+    EXPECT_EQ(threeD[1][0][1], 333);
+    EXPECT_EQ(threeD[1][1][0], 444);
+    EXPECT_EQ(threeD[1][1][1], 555);
+    EXPECT_EQ(threeD[1][2][0], 666);
+    EXPECT_EQ(threeD[1][2][1], 777);
+    EXPECT_EQ(threeD[2][0][0], 2222);
+    EXPECT_EQ(threeD[2][0][1], 3333);
+    EXPECT_EQ(threeD[2][1][0], 4444);
+    EXPECT_EQ(threeD[2][1][1], 5555);
+    EXPECT_EQ(threeD[2][2][0], 6666);
+    EXPECT_EQ(threeD[2][2][1], 7777);
+    EXPECT_EQ(threeD[3][0][0], 22222);
+    EXPECT_EQ(threeD[3][0][1], 33333);
+    EXPECT_EQ(threeD[3][1][0], 44444);
+    EXPECT_EQ(threeD[3][1][1], 55555);
+    EXPECT_EQ(threeD[3][2][0], 66666);
+    EXPECT_EQ(threeD[3][2][1], 77777);
+
+    span.clear();
+    EXPECT_EQ(threeD[0][0][0], 0);
+    EXPECT_EQ(threeD[0][0][1], 0);
+    EXPECT_EQ(threeD[0][1][0], 0);
+    EXPECT_EQ(threeD[0][1][1], 0);
+    EXPECT_EQ(threeD[0][2][0], 0);
+    EXPECT_EQ(threeD[0][2][1], 0);
+    EXPECT_EQ(threeD[1][0][0], 0);
+    EXPECT_EQ(threeD[1][0][1], 0);
+    EXPECT_EQ(threeD[1][1][0], 0);
+    EXPECT_EQ(threeD[1][1][1], 0);
+    EXPECT_EQ(threeD[1][2][0], 0);
+    EXPECT_EQ(threeD[1][2][1], 0);
+    EXPECT_EQ(threeD[2][0][0], 0);
+    EXPECT_EQ(threeD[2][0][1], 0);
+    EXPECT_EQ(threeD[2][1][0], 0);
+    EXPECT_EQ(threeD[2][1][1], 0);
+    EXPECT_EQ(threeD[2][2][0], 0);
+    EXPECT_EQ(threeD[2][2][1], 0);
+    EXPECT_EQ(threeD[3][0][0], 0);
+    EXPECT_EQ(threeD[3][0][1], 0);
+    EXPECT_EQ(threeD[3][1][0], 0);
+    EXPECT_EQ(threeD[3][1][1], 0);
+    EXPECT_EQ(threeD[3][2][0], 0);
+    EXPECT_EQ(threeD[3][2][1], 0);
+
+    span.fill(11);
+    EXPECT_EQ(threeD[0][0][0], 11);
+    EXPECT_EQ(threeD[0][0][1], 11);
+    EXPECT_EQ(threeD[0][1][0], 11);
+    EXPECT_EQ(threeD[0][1][1], 11);
+    EXPECT_EQ(threeD[0][2][0], 11);
+    EXPECT_EQ(threeD[0][2][1], 11);
+    EXPECT_EQ(threeD[1][0][0], 11);
+    EXPECT_EQ(threeD[1][0][1], 11);
+    EXPECT_EQ(threeD[1][1][0], 11);
+    EXPECT_EQ(threeD[1][1][1], 11);
+    EXPECT_EQ(threeD[1][2][0], 11);
+    EXPECT_EQ(threeD[1][2][1], 11);
+    EXPECT_EQ(threeD[2][0][0], 11);
+    EXPECT_EQ(threeD[2][0][1], 11);
+    EXPECT_EQ(threeD[2][1][0], 11);
+    EXPECT_EQ(threeD[2][1][1], 11);
+    EXPECT_EQ(threeD[2][2][0], 11);
+    EXPECT_EQ(threeD[2][2][1], 11);
+    EXPECT_EQ(threeD[3][0][0], 11);
+    EXPECT_EQ(threeD[3][0][1], 11);
+    EXPECT_EQ(threeD[3][1][0], 11);
+    EXPECT_EQ(threeD[3][1][1], 11);
+    EXPECT_EQ(threeD[3][2][0], 11);
+    EXPECT_EQ(threeD[3][2][1], 11);
+
+    threeD[0][0][1] = 22;
+    threeD[0][1][0] = 33;
+    threeD[0][1][1] = 44;
+    threeD[0][2][0] = 55;
+    threeD[0][2][1] = 66;
+    threeD[1][0][0] = 111;
+    threeD[1][0][1] = 222;
+    threeD[1][1][0] = 333;
+    threeD[1][1][1] = 444;
+    threeD[1][2][0] = 555;
+    threeD[1][2][1] = 666;
+    threeD[2][0][0] = 1111;
+    threeD[2][0][1] = 2222;
+    threeD[2][1][0] = 3333;
+    threeD[2][1][1] = 4444;
+    threeD[2][2][0] = 5555;
+    threeD[2][2][1] = 6666;
+    threeD[3][0][0] = 11111;
+    threeD[3][0][1] = 22222;
+    threeD[3][1][0] = 33333;
+    threeD[3][1][1] = 44444;
+    threeD[3][2][0] = 55555;
+    threeD[3][2][1] = 66666; // {{11, 22, 33, 44, 55, 66}, {111, 222 ...}, {...}, {...}}
+    span.swap(as_1d(other)); // {{22, 33, 44, 55, 66, 77}, {222, 333 ...}, {...}, {...}}
+    EXPECT_EQ(threeD[0][0][0], 22);
+    EXPECT_EQ(threeD[0][0][1], 33);
+    EXPECT_EQ(threeD[0][1][0], 44);
+    EXPECT_EQ(threeD[0][1][1], 55);
+    EXPECT_EQ(threeD[0][2][0], 66);
+    EXPECT_EQ(threeD[0][2][1], 77);
+    EXPECT_EQ(threeD[1][0][0], 222);
+    EXPECT_EQ(threeD[1][0][1], 333);
+    EXPECT_EQ(threeD[1][1][0], 444);
+    EXPECT_EQ(threeD[1][1][1], 555);
+    EXPECT_EQ(threeD[1][2][0], 666);
+    EXPECT_EQ(threeD[1][2][1], 777);
+    EXPECT_EQ(threeD[2][0][0], 2222);
+    EXPECT_EQ(threeD[2][0][1], 3333);
+    EXPECT_EQ(threeD[2][1][0], 4444);
+    EXPECT_EQ(threeD[2][1][1], 5555);
+    EXPECT_EQ(threeD[2][2][0], 6666);
+    EXPECT_EQ(threeD[2][2][1], 7777);
+    EXPECT_EQ(threeD[3][0][0], 22222);
+    EXPECT_EQ(threeD[3][0][1], 33333);
+    EXPECT_EQ(threeD[3][1][0], 44444);
+    EXPECT_EQ(threeD[3][1][1], 55555);
+    EXPECT_EQ(threeD[3][2][0], 66666);
+    EXPECT_EQ(threeD[3][2][1], 77777);
+    
+    EXPECT_EQ(other[0][0][0], 11);
+    EXPECT_EQ(other[0][0][1], 22);
+    EXPECT_EQ(other[0][1][0], 33);
+    EXPECT_EQ(other[0][1][1], 44);
+    EXPECT_EQ(other[0][2][0], 55);
+    EXPECT_EQ(other[0][2][1], 66);
+    EXPECT_EQ(other[1][0][0], 111);
+    EXPECT_EQ(other[1][0][1], 222);
+    EXPECT_EQ(other[1][1][0], 333);
+    EXPECT_EQ(other[1][1][1], 444);
+    EXPECT_EQ(other[1][2][0], 555);
+    EXPECT_EQ(other[1][2][1], 666);
+    EXPECT_EQ(other[2][0][0], 1111);
+    EXPECT_EQ(other[2][0][1], 2222);
+    EXPECT_EQ(other[2][1][0], 3333);
+    EXPECT_EQ(other[2][1][1], 4444);
+    EXPECT_EQ(other[2][2][0], 5555);
+    EXPECT_EQ(other[2][2][1], 6666);
+    EXPECT_EQ(other[3][0][0], 11111);
+    EXPECT_EQ(other[3][0][1], 22222);
+    EXPECT_EQ(other[3][1][0], 33333);
+    EXPECT_EQ(other[3][1][1], 44444);
+    EXPECT_EQ(other[3][2][0], 55555);
+    EXPECT_EQ(other[3][2][1], 66666);
+    
+    EXPECT_TRUE(is_flat_mdspan<Flatspan>::value);
+    EXPECT_TRUE(is_flat_mdspan<const Flatspan>::value);
+    EXPECT_TRUE(is_flat_mdspan_v<Flatspan>);
+    EXPECT_TRUE(is_flat_mdspan_v<const Flatspan>);
+    EXPECT_FALSE(is_flat_mdspan<decltype(threeD)>::value);
+    EXPECT_FALSE(is_flat_mdspan<decltype(threeD)>::value);
+}
+
+}

--- a/include/rarecpp/editor.h
+++ b/include/rarecpp/editor.h
@@ -7239,7 +7239,11 @@ namespace RareEdit
 
         template <typename Usr> static constexpr bool hasAfterActionOp = RareTs::op_exists_v<AfterActionOp, Usr>;
 
-        void notifyAfterAction() { static_cast<Agent<Data, User, Editor<Tracked>> &>(editable).user.afterAction(actionFirstEvent.size()-1); }
+        void notifyAfterAction()
+        {
+            if ( actionFirstEvent.back() < editable.eventOffsets.size() )
+                static_cast<Agent<Data, User, Editor<Tracked>> &>(editable).user.afterAction(actionFirstEvent.size()-1);
+        }
 
     protected:
 

--- a/include/rarecpp/editor.h
+++ b/include/rarecpp/editor.h
@@ -460,6 +460,11 @@ namespace RareEdit
         template <std::size_t I> constexpr const auto & index() { return std::get<I>((Keys &)(*this));}
     };
 
+    template <class Input>
+    using MakePath = PathTaggedKeys<typename Input::keys, typename Input::path, typename Input::editor_type>;
+
+    #define PATH(...) RareEdit::MakePath<decltype(__VA_ARGS__)>
+
     struct Rotation
     {
         std::size_t startIndex;
@@ -6910,11 +6915,6 @@ namespace RareEdit
         };
 
         static inline Editor<Tracked> root {nullptr}; // Represents the root of the data structure, used by client code to create paths
-
-        template <class Input>
-        using MakePath = PathTaggedKeys<typename Input::keys, typename Input::path, typename Input::editor_type>;
-
-        #define PATH(...) MakePath<decltype(__VA_ARGS__)>
 
     public:
         const edit_root & view; // Used to view selections data (and potentially other info associated with particular data paths)

--- a/include/rarecpp/editor.h
+++ b/include/rarecpp/editor.h
@@ -1531,7 +1531,7 @@ namespace RareEdit
             }
             else if constexpr ( std::is_array_v<value_type> )
             {
-                auto span = as_1d<value_type>(value);
+                auto span = as_1d<const value_type>(value);
                 constexpr auto size = static_cast<index_type>(decltype(span)::size);
                 events.insert(events.end(), reinterpret_cast<const std::uint8_t*>(&size), reinterpret_cast<const std::uint8_t*>(&size)+sizeof(size));
                 for ( auto it = span.flatBegin(); it != span.flatEnd(); ++it )
@@ -1952,7 +1952,7 @@ namespace RareEdit
                         for ( ; i>=0; --i )
                             notifyElementRemoved(user, Route{keys}, static_cast<std::size_t>(i));
                     }
-                    else
+                    else if constexpr ( requires{ref = std::forward<Value>(value);} )
                         ref = std::forward<Value>(value);
 
                     if constexpr ( isIterable && hasElementAddedOp<Route> )
@@ -2040,7 +2040,7 @@ namespace RareEdit
                                 }
                             }
                         }
-                        else
+                        else if constexpr ( requires{ref[0] = value;} )
                         {
                             for ( auto setIndex : setIndexes )
                                 ref[setIndex] = value; // Make the change

--- a/include/rarecpp/editor.h
+++ b/include/rarecpp/editor.h
@@ -22,13 +22,15 @@
 namespace RareEdit
 {
     using RareTs::type_tags;
-    template <typename SizeType> struct IndexSize { using type = SizeType; };
+    template <typename SizeType> struct IndexSizeType { using type = SizeType; };
+
+    template <typename SizeType> inline constexpr IndexSizeType<SizeType> IndexSize;
 
     template <typename T>
     constexpr auto defaultIndexType()
     {
-        if constexpr ( RareTs::Notes<T>::template hasNote<RareEdit::IndexSize>() )
-            return RareTs::Notes<T>::template getNote<RareEdit::IndexSize>();
+        if constexpr ( RareTs::Notes<T>::template hasNote<RareEdit::IndexSizeType>() )
+            return RareTs::Notes<T>::template getNote<RareEdit::IndexSizeType>();
         else
             return std::type_identity<std::size_t>{};
     }
@@ -574,6 +576,14 @@ namespace RareEdit
                 Keys {keys},
                 RareTs::Class::template adapt_member<edit_member<Edit, default_index_type, RootData, T, Keys, Pathway...>::template type, T, Is> {{ root, keys }}...,
                 root(root) {}
+
+            template <class U> constexpr void operator=(U && value) {
+                if constexpr ( has_path_selections<Pathway...> )
+                    root.template setL<Pathway...>(std::forward<U>(value), (Keys &)(*this));
+                else
+                    root.template set<Pathway...>(std::forward<U>(value), (Keys &)(*this));
+            }
+
         private:
             Edit & root;
         };
@@ -604,8 +614,8 @@ namespace RareEdit
                 else
                     return std::type_identity<std::size_t>{};
             }
-            else if constexpr ( Member::template hasNote<RareEdit::IndexSize>() )
-                return Member::template getNote<RareEdit::IndexSize>();
+            else if constexpr ( Member::template hasNote<RareEdit::IndexSizeType>() )
+                return Member::template getNote<RareEdit::IndexSizeType>();
             else
                 return std::type_identity<DefaultIndexType>{};
         }

--- a/include/rarecpp/editor.h
+++ b/include/rarecpp/editor.h
@@ -7260,7 +7260,11 @@ namespace RareEdit
                 if ( redoCount > 0 )
                     elideRedos();
 
-                actionFirstEvent.push_back(editable.eventOffsets.size());
+                if ( actionFirstEvent.empty() || actionFirstEvent.back() < editable.eventOffsets.size() ||
+                    (actionFirstEvent.back() & flagElidedRedos) == flagElidedRedos ) // If the last action is empty, and not a marker, no new action is needed
+                {
+                    actionFirstEvent.push_back(editable.eventOffsets.size());
+                }
             }
             return Editor<Tracked>{this};
         };
@@ -7282,7 +7286,11 @@ namespace RareEdit
                 if ( redoCount > 0 )
                     elideRedos();
 
-                actionFirstEvent.push_back(editable.eventOffsets.size());
+                if ( actionFirstEvent.empty() || actionFirstEvent.back() < editable.eventOffsets.size() ||
+                    (actionFirstEvent.back() & flagElidedRedos) == flagElidedRedos ) // If the last action is empty, and not a marker, no new action is needed
+                {
+                    actionFirstEvent.push_back(editable.eventOffsets.size());
+                }
             }
             return Editor<Tracked>{this};
         };

--- a/include/rarecpp/editor.h
+++ b/include/rarecpp/editor.h
@@ -647,14 +647,14 @@ namespace RareEdit
             else
                 agent.template set<Pathway...>(std::forward<U>(value), (Keys &)(*this));
         }
-        template <class U> void operator +=(U && value) { RandomAccess::agent.template plusEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
-        template <class U> void operator -=(U && value) { RandomAccess::agent.template minusEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
-        template <class U> void operator *=(U && value) { RandomAccess::agent.template multEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
-        template <class U> void operator /=(U && value) { RandomAccess::agent.template divEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
-        template <class U> void operator %=(U && value) { RandomAccess::agent.template modEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
-        template <class U> void operator ^=(U && value) { RandomAccess::agent.template xorEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
-        template <class U> void operator &=(U && value) { RandomAccess::agent.template andEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
-        template <class U> void operator |=(U && value) { RandomAccess::agent.template orEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
+        template <class U> void operator +=(U && value) { agent.template plusEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
+        template <class U> void operator -=(U && value) { agent.template minusEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
+        template <class U> void operator *=(U && value) { agent.template multEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
+        template <class U> void operator /=(U && value) { agent.template divEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
+        template <class U> void operator %=(U && value) { agent.template modEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
+        template <class U> void operator ^=(U && value) { agent.template xorEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
+        template <class U> void operator &=(U && value) { agent.template andEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
+        template <class U> void operator |=(U && value) { agent.template orEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
     };
 
     template <class Agent, class default_index_type, class RootData, class T, class Keys, std::size_t I, class ... Pathway>

--- a/include/rarecpp/editor.h
+++ b/include/rarecpp/editor.h
@@ -2230,7 +2230,7 @@ namespace RareEdit
                 {
                     auto prevValue = ref;
                     ref += std::forward<Value>(value);
-                    serializeValue<Member>(static_cast<std::remove_cvref_t<decltype(ref)>>(value)); // Value set to
+                    serializeValue<Member>(static_cast<std::remove_cvref_t<decltype(ref)>>(ref)); // Value set to
                     serializeValue<Member>(prevValue); // Value before changing
                     notifyValueChanged(user, Route{keys}, prevValue, ref);
                 }
@@ -2257,7 +2257,7 @@ namespace RareEdit
                 {
                     auto prevValue = ref;
                     ref -= std::forward<Value>(value);
-                    serializeValue<Member>(static_cast<std::remove_cvref_t<decltype(ref)>>(value)); // Value set to
+                    serializeValue<Member>(static_cast<std::remove_cvref_t<decltype(ref)>>(ref)); // Value set to
                     serializeValue<Member>(prevValue); // Value before changing
                     notifyValueChanged(user, Route{keys}, prevValue, ref);
                 }
@@ -2284,7 +2284,7 @@ namespace RareEdit
                 {
                     auto prevValue = ref;
                     ref *= std::forward<Value>(value);
-                    serializeValue<Member>(static_cast<std::remove_cvref_t<decltype(ref)>>(value)); // Value set to
+                    serializeValue<Member>(static_cast<std::remove_cvref_t<decltype(ref)>>(ref)); // Value set to
                     serializeValue<Member>(prevValue); // Value before changing
                     notifyValueChanged(user, Route{keys}, prevValue, ref);
                 }
@@ -2311,7 +2311,7 @@ namespace RareEdit
                 {
                     auto prevValue = ref;
                     ref /= std::forward<Value>(value);
-                    serializeValue<Member>(static_cast<std::remove_cvref_t<decltype(ref)>>(value)); // Value set to
+                    serializeValue<Member>(static_cast<std::remove_cvref_t<decltype(ref)>>(ref)); // Value set to
                     serializeValue<Member>(prevValue); // Value before changing
                     notifyValueChanged(user, Route{keys}, prevValue, ref);
                 }
@@ -2338,7 +2338,7 @@ namespace RareEdit
                 {
                     auto prevValue = ref;
                     ref %= std::forward<Value>(value);
-                    serializeValue<Member>(static_cast<std::remove_cvref_t<decltype(ref)>>(value)); // Value set to
+                    serializeValue<Member>(static_cast<std::remove_cvref_t<decltype(ref)>>(ref)); // Value set to
                     serializeValue<Member>(prevValue); // Value before changing
                     notifyValueChanged(user, Route{keys}, prevValue, ref);
                 }
@@ -2365,7 +2365,7 @@ namespace RareEdit
                 {
                     auto prevValue = ref;
                     ref ^= std::forward<Value>(value);
-                    serializeValue<Member>(static_cast<std::remove_cvref_t<decltype(ref)>>(value)); // Value set to
+                    serializeValue<Member>(static_cast<std::remove_cvref_t<decltype(ref)>>(ref)); // Value set to
                     serializeValue<Member>(prevValue); // Value before changing
                     notifyValueChanged(user, Route{keys}, prevValue, ref);
                 }
@@ -2392,7 +2392,7 @@ namespace RareEdit
                 {
                     auto prevValue = ref;
                     ref &= std::forward<Value>(value);
-                    serializeValue<Member>(static_cast<std::remove_cvref_t<decltype(ref)>>(value)); // Value set to
+                    serializeValue<Member>(static_cast<std::remove_cvref_t<decltype(ref)>>(ref)); // Value set to
                     serializeValue<Member>(prevValue); // Value before changing
                     notifyValueChanged(user, Route{keys}, prevValue, ref);
                 }
@@ -2419,7 +2419,7 @@ namespace RareEdit
                 {
                     auto prevValue = ref;
                     ref |= std::forward<Value>(value);
-                    serializeValue<Member>(static_cast<std::remove_cvref_t<decltype(ref)>>(value)); // Value set to
+                    serializeValue<Member>(static_cast<std::remove_cvref_t<decltype(ref)>>(ref)); // Value set to
                     serializeValue<Member>(prevValue); // Value before changing
                     notifyValueChanged(user, Route{keys}, prevValue, ref);
                 }
@@ -5539,7 +5539,8 @@ namespace RareEdit
                 break;
                 case Op::Assign:
                 {
-                    if constexpr ( !std::is_void_v<element_type> && !RareTs::is_static_array_v<value_type> && !std::is_same_v<std::string, value_type> && requires{ref.assign(0, {});} )
+                    if constexpr ( !std::is_void_v<element_type> && !RareTs::is_static_array_v<value_type> &&
+                        !RareTs::is_optional_v<value_type> && !std::is_same_v<std::string, value_type> && requires{ref.assign(0, {});} )
                     {
                         std::size_t count = static_cast<std::size_t>(readIndex<index_type>(offset));
                         auto value = readValue<element_type, Member>(offset);
@@ -5580,7 +5581,8 @@ namespace RareEdit
                 break;
                 case Op::AssignDefault:
                 {
-                    if constexpr ( !std::is_void_v<element_type> && !RareTs::is_static_array_v<value_type> && !std::is_same_v<std::string, value_type> && requires{ref = value_type(0);} )
+                    if constexpr ( !std::is_void_v<element_type> && !RareTs::is_static_array_v<value_type> &&
+                        !RareTs::is_optional_v<value_type> && !std::is_same_v<std::string, value_type> && requires{ref = value_type(0);} )
                     {
                         std::size_t size = static_cast<std::size_t>(readIndex<index_type>(offset));
                         if constexpr ( hasElementRemovedOp<Route> )
@@ -5909,7 +5911,8 @@ namespace RareEdit
                 break;
                 case Op::AppendN:
                 {
-                    if constexpr ( !std::is_void_v<element_type> && !RareTs::is_static_array_v<value_type> && !std::is_same_v<std::string, value_type> && requires{ref.push_back(element_type{});} )
+                    if constexpr ( !std::is_void_v<element_type> && !RareTs::is_static_array_v<value_type> &&
+                        !RareTs::is_optional_v<value_type> && !std::is_same_v<std::string, value_type> && requires{ref.push_back(element_type{});} )
                     {
                         auto count = static_cast<std::size_t>(readIndex<index_type>(offset));
                         for ( std::size_t i=0; i<count; ++i )
@@ -5923,7 +5926,8 @@ namespace RareEdit
                 break;
                 case Op::Insert:
                 {
-                    if constexpr ( !std::is_void_v<element_type> && !RareTs::is_static_array_v<value_type> && !std::is_same_v<std::string, value_type> && requires{ref.insert(ref.begin(), std::declval<element_type>());} )
+                    if constexpr ( !std::is_void_v<element_type> && !RareTs::is_static_array_v<value_type> &&
+                        !RareTs::is_optional_v<value_type> && !std::is_same_v<std::string, value_type> && requires{ref.insert(ref.begin(), std::declval<element_type>());} )
                     {
                         auto insertionIndex = readIndex<index_type>(offset);
                         auto insertedValue = readValue<element_type, Member>(offset);
@@ -5953,7 +5957,8 @@ namespace RareEdit
                 break;
                 case Op::InsertN:
                 {
-                    if constexpr ( !std::is_void_v<element_type> && !RareTs::is_static_array_v<value_type> && !std::is_same_v<std::string, value_type> && requires {ref.insert(ref.begin(), std::declval<element_type>());} )
+                    if constexpr ( !std::is_void_v<element_type> && !RareTs::is_static_array_v<value_type> &&
+                        !RareTs::is_optional_v<value_type> && !std::is_same_v<std::string, value_type> && requires {ref.insert(ref.begin(), std::declval<element_type>());} )
                     {
                         std::size_t insertionCount = static_cast<std::size_t>(readIndex<index_type>(offset));
                         auto insertionIndex = readIndex<index_type>(offset);
@@ -5994,7 +5999,8 @@ namespace RareEdit
                 break;
                 case Op::Remove:
                 {
-                    if constexpr ( !std::is_void_v<element_type> && !RareTs::is_static_array_v<value_type> && !std::is_same_v<std::string, value_type> && requires{ref.erase(ref.begin());} )
+                    if constexpr ( !std::is_void_v<element_type> && !RareTs::is_static_array_v<value_type> &&
+                        !RareTs::is_optional_v<value_type> && !std::is_same_v<std::string, value_type> && requires{ref.erase(ref.begin());} )
                     {
                         auto removalIndex = readIndex<index_type>(offset);
                         ref.erase(std::next(ref.begin(), static_cast<std::ptrdiff_t>(removalIndex)));
@@ -6029,7 +6035,8 @@ namespace RareEdit
                 break;
                 case Op::RemoveN:
                 {
-                    if constexpr ( !std::is_void_v<element_type> && !RareTs::is_static_array_v<value_type> && !std::is_same_v<std::string, value_type> && requires{ref.erase(ref.begin());} )
+                    if constexpr ( !std::is_void_v<element_type> && !RareTs::is_static_array_v<value_type> &&
+                        !RareTs::is_optional_v<value_type> && !std::is_same_v<std::string, value_type> && requires{ref.erase(ref.begin());} )
                     {
                         auto & sel = getSelections<Pathway...>();
                         std::size_t removalCount = static_cast<std::size_t>(readIndex<index_type>(offset));
@@ -6085,7 +6092,8 @@ namespace RareEdit
                 break;
                 case Op::RemoveL:
                 {
-                    if constexpr ( !std::is_void_v<element_type> && !RareTs::is_static_array_v<value_type> && !std::is_same_v<std::string, value_type> && requires{ref.erase(ref.begin());} )
+                    if constexpr ( !std::is_void_v<element_type> && !RareTs::is_static_array_v<value_type> &&
+                        !RareTs::is_optional_v<value_type> && !std::is_same_v<std::string, value_type> && requires{ref.erase(ref.begin());} )
                     {
                         std::size_t removalCount = static_cast<std::size_t>(readIndex<index_type>(offset));
                         auto removalIndexes = readIndexes<index_type>(offset, removalCount);
@@ -7393,6 +7401,8 @@ namespace RareEdit
             if ( actionReferenceCount != 0 )
                 throw std::logic_error("Cannot clear history while an action is active");
 
+            pendingActionUserData = {};
+            pendingActionStart = 0;
             history.clear();
             redoCount = 0;
             redoSize = 0;

--- a/include/rarecpp/editor.h
+++ b/include/rarecpp/editor.h
@@ -79,8 +79,9 @@ namespace RareEdit
             else
                 return flat_mdspan<T, Extents...>(&data[size/Extent*i]);
         }
+        template <typename U>
         struct It {
-            flat_mdspan* obj;
+            U* obj;
             std::size_t i;
             constexpr void operator++() { ++i; }
             constexpr decltype(auto) operator*() const { return (*obj)[i]; }
@@ -101,7 +102,7 @@ namespace RareEdit
         }
         constexpr void clear() { std::fill(flatBegin(), flatEnd(), T{}); }
         constexpr void fill(const T & value) { std::fill(flatBegin(), flatEnd(), value); }
-        constexpr void swap(flat_mdspan & other) {
+        constexpr void swap(flat_mdspan && other) {
             for ( std::size_t i=0; i<size; ++i )
                 std::swap(data[i], other.data[i]);
         }
@@ -616,18 +617,13 @@ namespace RareEdit
     {
         switch ( op )
         {
-            case Op::ClearSelections: return true;
-            case Op::SelectAll: return true;
-            case Op::Select: return true;
-            case Op::SelectN: return true;
-            case Op::Deselect: return true;
-            case Op::DeselectN: return true;
-            case Op::ToggleSelection: return true;
-            case Op::ToggleSelectionN: return true;
-            case Op::SortSelections: return true;
-            case Op::SortSelectionsDesc: return true;
+            case Op::ClearSelections: case Op::SelectAll: case Op::Select: case Op::SelectN:
+            case Op::Deselect: case Op::DeselectN: case Op::ToggleSelection: case Op::ToggleSelectionN:
+            case Op::SortSelections: case Op::SortSelectionsDesc:
+                return true;
+            default:
+                return false;
         }
-        return false;
     }
 
     // Go to the Ith member of the current object
@@ -7507,7 +7503,7 @@ namespace RareEdit
                 if ( (actions[static_cast<std::size_t>(i)].firstEventIndex & flagElidedRedos) == flagElidedRedos )
                     i -= static_cast<std::ptrdiff_t>(actions[static_cast<std::size_t>(i)].firstEventIndex & maskElidedRedoSize);
                 else
-                    return i+1;
+                    return static_cast<std::size_t>(i)+1;
             }
             return 0;
         }

--- a/include/rarecpp/editor.h
+++ b/include/rarecpp/editor.h
@@ -2173,7 +2173,7 @@ namespace RareEdit
                 }
                 else
                 {
-                    serializeValue<Member>(ref + value); // Value set to
+                    serializeValue<Member>(std::remove_cvref_t<decltype(ref)>(ref + value)); // Value set to
                     serializeValue<Member>(ref); // Value before changing
                     ref += std::forward<Value>(value);
                 }
@@ -2200,7 +2200,7 @@ namespace RareEdit
                 }
                 else
                 {
-                    serializeValue<Member>(ref - value); // Value set to
+                    serializeValue<Member>(std::remove_cvref_t<decltype(ref)>(ref - value)); // Value set to
                     serializeValue<Member>(ref); // Value before changing
                     ref -= std::forward<Value>(value);
                 }
@@ -2227,7 +2227,7 @@ namespace RareEdit
                 }
                 else
                 {
-                    serializeValue<Member>(ref * value); // Value set to
+                    serializeValue<Member>(std::remove_cvref_t<decltype(ref)>(ref * value)); // Value set to
                     serializeValue<Member>(ref); // Value before changing
                     ref *= std::forward<Value>(value);
                 }
@@ -2254,7 +2254,7 @@ namespace RareEdit
                 }
                 else
                 {
-                    serializeValue<Member>(ref / value); // Value set to
+                    serializeValue<Member>(std::remove_cvref_t<decltype(ref)>(ref / value)); // Value set to
                     serializeValue<Member>(ref); // Value before changing
                     ref /= std::forward<Value>(value);
                 }
@@ -2281,7 +2281,7 @@ namespace RareEdit
                 }
                 else
                 {
-                    serializeValue<Member>(ref % value); // Value set to
+                    serializeValue<Member>(std::remove_cvref_t<decltype(ref)>(ref % value)); // Value set to
                     serializeValue<Member>(ref); // Value before changing
                     ref %= std::forward<Value>(value);
                 }
@@ -2308,7 +2308,7 @@ namespace RareEdit
                 }
                 else
                 {
-                    serializeValue<Member>(ref ^ value); // Value set to
+                    serializeValue<Member>(std::remove_cvref_t<decltype(ref)>(ref ^ value)); // Value set to
                     serializeValue<Member>(ref); // Value before changing
                     ref ^= std::forward<Value>(value);
                 }
@@ -2335,7 +2335,7 @@ namespace RareEdit
                 }
                 else
                 {
-                    serializeValue<Member>(ref & value); // Value set to
+                    serializeValue<Member>(std::remove_cvref_t<decltype(ref)>(ref & value)); // Value set to
                     serializeValue<Member>(ref); // Value before changing
                     ref &= std::forward<Value>(value);
                 }
@@ -2362,7 +2362,7 @@ namespace RareEdit
                 }
                 else
                 {
-                    serializeValue<Member>(ref | value); // Value set to
+                    serializeValue<Member>(std::remove_cvref_t<decltype(ref)>(ref | value)); // Value set to
                     serializeValue<Member>(ref); // Value before changing
                     ref |= std::forward<Value>(value);
                 }

--- a/include/rarecpp/editor.h
+++ b/include/rarecpp/editor.h
@@ -1041,6 +1041,15 @@ namespace RareEdit
                 else
                     RandomAccess::agent.template set<Pathway...>(std::forward<U>(value), (Keys &)(*this));
             }
+            template <class U> void operator +=(U && value) { RandomAccess::agent.template plusEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
+            template <class U> void operator -=(U && value) { RandomAccess::agent.template minusEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
+            template <class U> void operator *=(U && value) { RandomAccess::agent.template multEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
+            template <class U> void operator /=(U && value) { RandomAccess::agent.template divEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
+            template <class U> void operator %=(U && value) { RandomAccess::agent.template modEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
+            template <class U> void operator ^=(U && value) { RandomAccess::agent.template xorEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
+            template <class U> void operator &=(U && value) { RandomAccess::agent.template andEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
+            template <class U> void operator |=(U && value) { RandomAccess::agent.template orEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
+
             template <class SetIndexes, class Value> void set(SetIndexes && indexes, Value && value) { RandomAccess::agent.template setN<Pathway...>(indexes, std::forward<Value>(value), (Keys &)(*this)); }
             template <class U> void append(U && value) {
                 if constexpr ( RareTs::is_iterable_v<std::remove_cvref_t<U>> && !RareTs::is_optional_v<std::remove_cvref_t<U>> )
@@ -2129,6 +2138,222 @@ namespace RareEdit
                         for ( std::size_t i=0; i<std::size(ref); ++i )
                             notifyElementAdded(user, Route{newKeys}, i);
                     }
+                }
+            });
+        }
+
+        template <class ... Pathway, class Value, class Keys>
+        void plusEq(Value && value, Keys & keys)
+        {
+            eventOffsets.push_back(events.size());
+            events.push_back(uint8_t(Op::Set)); // "Set like operation"
+            serializePathway<Pathway...>(keys);
+
+            operateOn<Pathway...>(t, keys, [&]<class Member, class Route>(auto & ref, type_tags<Member, Route>) {
+                
+                using value_type = std::remove_cvref_t<decltype(ref)>;
+                if constexpr ( hasValueChangedOp<Route, value_type> )
+                {
+                    auto prevValue = ref;
+                    ref += std::forward<Value>(value);
+                    serializeValue<Member>(static_cast<std::remove_cvref_t<decltype(ref)>>(value)); // Value set to
+                    serializeValue<Member>(prevValue); // Value before changing
+                    notifyValueChanged(user, Route{keys}, prevValue, ref);
+                }
+                else
+                {
+                    serializeValue<Member>(ref + value); // Value set to
+                    serializeValue<Member>(ref); // Value before changing
+                    ref += std::forward<Value>(value);
+                }
+            });
+        }
+
+        template <class ... Pathway, class Value, class Keys>
+        void minusEq(Value && value, Keys & keys)
+        {
+            eventOffsets.push_back(events.size());
+            events.push_back(uint8_t(Op::Set)); // "Set like operation"
+            serializePathway<Pathway...>(keys);
+
+            operateOn<Pathway...>(t, keys, [&]<class Member, class Route>(auto & ref, type_tags<Member, Route>) {
+                
+                using value_type = std::remove_cvref_t<decltype(ref)>;
+                if constexpr ( hasValueChangedOp<Route, value_type> )
+                {
+                    auto prevValue = ref;
+                    ref -= std::forward<Value>(value);
+                    serializeValue<Member>(static_cast<std::remove_cvref_t<decltype(ref)>>(value)); // Value set to
+                    serializeValue<Member>(prevValue); // Value before changing
+                    notifyValueChanged(user, Route{keys}, prevValue, ref);
+                }
+                else
+                {
+                    serializeValue<Member>(ref - value); // Value set to
+                    serializeValue<Member>(ref); // Value before changing
+                    ref -= std::forward<Value>(value);
+                }
+            });
+        }
+
+        template <class ... Pathway, class Value, class Keys>
+        void multEq(Value && value, Keys & keys)
+        {
+            eventOffsets.push_back(events.size());
+            events.push_back(uint8_t(Op::Set)); // "Set like operation"
+            serializePathway<Pathway...>(keys);
+
+            operateOn<Pathway...>(t, keys, [&]<class Member, class Route>(auto & ref, type_tags<Member, Route>) {
+                
+                using value_type = std::remove_cvref_t<decltype(ref)>;
+                if constexpr ( hasValueChangedOp<Route, value_type> )
+                {
+                    auto prevValue = ref;
+                    ref *= std::forward<Value>(value);
+                    serializeValue<Member>(static_cast<std::remove_cvref_t<decltype(ref)>>(value)); // Value set to
+                    serializeValue<Member>(prevValue); // Value before changing
+                    notifyValueChanged(user, Route{keys}, prevValue, ref);
+                }
+                else
+                {
+                    serializeValue<Member>(ref * value); // Value set to
+                    serializeValue<Member>(ref); // Value before changing
+                    ref *= std::forward<Value>(value);
+                }
+            });
+        }
+
+        template <class ... Pathway, class Value, class Keys>
+        void divEq(Value && value, Keys & keys)
+        {
+            eventOffsets.push_back(events.size());
+            events.push_back(uint8_t(Op::Set)); // "Set like operation"
+            serializePathway<Pathway...>(keys);
+
+            operateOn<Pathway...>(t, keys, [&]<class Member, class Route>(auto & ref, type_tags<Member, Route>) {
+                
+                using value_type = std::remove_cvref_t<decltype(ref)>;
+                if constexpr ( hasValueChangedOp<Route, value_type> )
+                {
+                    auto prevValue = ref;
+                    ref /= std::forward<Value>(value);
+                    serializeValue<Member>(static_cast<std::remove_cvref_t<decltype(ref)>>(value)); // Value set to
+                    serializeValue<Member>(prevValue); // Value before changing
+                    notifyValueChanged(user, Route{keys}, prevValue, ref);
+                }
+                else
+                {
+                    serializeValue<Member>(ref / value); // Value set to
+                    serializeValue<Member>(ref); // Value before changing
+                    ref /= std::forward<Value>(value);
+                }
+            });
+        }
+
+        template <class ... Pathway, class Value, class Keys>
+        void modEq(Value && value, Keys & keys)
+        {
+            eventOffsets.push_back(events.size());
+            events.push_back(uint8_t(Op::Set)); // "Set like operation"
+            serializePathway<Pathway...>(keys);
+
+            operateOn<Pathway...>(t, keys, [&]<class Member, class Route>(auto & ref, type_tags<Member, Route>) {
+                
+                using value_type = std::remove_cvref_t<decltype(ref)>;
+                if constexpr ( hasValueChangedOp<Route, value_type> )
+                {
+                    auto prevValue = ref;
+                    ref %= std::forward<Value>(value);
+                    serializeValue<Member>(static_cast<std::remove_cvref_t<decltype(ref)>>(value)); // Value set to
+                    serializeValue<Member>(prevValue); // Value before changing
+                    notifyValueChanged(user, Route{keys}, prevValue, ref);
+                }
+                else
+                {
+                    serializeValue<Member>(ref % value); // Value set to
+                    serializeValue<Member>(ref); // Value before changing
+                    ref %= std::forward<Value>(value);
+                }
+            });
+        }
+
+        template <class ... Pathway, class Value, class Keys>
+        void xorEq(Value && value, Keys & keys)
+        {
+            eventOffsets.push_back(events.size());
+            events.push_back(uint8_t(Op::Set)); // "Set like operation"
+            serializePathway<Pathway...>(keys);
+
+            operateOn<Pathway...>(t, keys, [&]<class Member, class Route>(auto & ref, type_tags<Member, Route>) {
+                
+                using value_type = std::remove_cvref_t<decltype(ref)>;
+                if constexpr ( hasValueChangedOp<Route, value_type> )
+                {
+                    auto prevValue = ref;
+                    ref ^= std::forward<Value>(value);
+                    serializeValue<Member>(static_cast<std::remove_cvref_t<decltype(ref)>>(value)); // Value set to
+                    serializeValue<Member>(prevValue); // Value before changing
+                    notifyValueChanged(user, Route{keys}, prevValue, ref);
+                }
+                else
+                {
+                    serializeValue<Member>(ref ^ value); // Value set to
+                    serializeValue<Member>(ref); // Value before changing
+                    ref ^= std::forward<Value>(value);
+                }
+            });
+        }
+
+        template <class ... Pathway, class Value, class Keys>
+        void andEq(Value && value, Keys & keys)
+        {
+            eventOffsets.push_back(events.size());
+            events.push_back(uint8_t(Op::Set)); // "Set like operation"
+            serializePathway<Pathway...>(keys);
+
+            operateOn<Pathway...>(t, keys, [&]<class Member, class Route>(auto & ref, type_tags<Member, Route>) {
+                
+                using value_type = std::remove_cvref_t<decltype(ref)>;
+                if constexpr ( hasValueChangedOp<Route, value_type> )
+                {
+                    auto prevValue = ref;
+                    ref &= std::forward<Value>(value);
+                    serializeValue<Member>(static_cast<std::remove_cvref_t<decltype(ref)>>(value)); // Value set to
+                    serializeValue<Member>(prevValue); // Value before changing
+                    notifyValueChanged(user, Route{keys}, prevValue, ref);
+                }
+                else
+                {
+                    serializeValue<Member>(ref & value); // Value set to
+                    serializeValue<Member>(ref); // Value before changing
+                    ref &= std::forward<Value>(value);
+                }
+            });
+        }
+
+        template <class ... Pathway, class Value, class Keys>
+        void orEq(Value && value, Keys & keys)
+        {
+            eventOffsets.push_back(events.size());
+            events.push_back(uint8_t(Op::Set)); // "Set like operation"
+            serializePathway<Pathway...>(keys);
+
+            operateOn<Pathway...>(t, keys, [&]<class Member, class Route>(auto & ref, type_tags<Member, Route>) {
+                
+                using value_type = std::remove_cvref_t<decltype(ref)>;
+                if constexpr ( hasValueChangedOp<Route, value_type> )
+                {
+                    auto prevValue = ref;
+                    ref |= std::forward<Value>(value);
+                    serializeValue<Member>(static_cast<std::remove_cvref_t<decltype(ref)>>(value)); // Value set to
+                    serializeValue<Member>(prevValue); // Value before changing
+                    notifyValueChanged(user, Route{keys}, prevValue, ref);
+                }
+                else
+                {
+                    serializeValue<Member>(ref | value); // Value set to
+                    serializeValue<Member>(ref); // Value before changing
+                    ref |= std::forward<Value>(value);
                 }
             });
         }

--- a/include/rarecpp/editor.h
+++ b/include/rarecpp/editor.h
@@ -647,6 +647,14 @@ namespace RareEdit
             else
                 agent.template set<Pathway...>(std::forward<U>(value), (Keys &)(*this));
         }
+        template <class U> void operator +=(U && value) { RandomAccess::agent.template plusEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
+        template <class U> void operator -=(U && value) { RandomAccess::agent.template minusEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
+        template <class U> void operator *=(U && value) { RandomAccess::agent.template multEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
+        template <class U> void operator /=(U && value) { RandomAccess::agent.template divEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
+        template <class U> void operator %=(U && value) { RandomAccess::agent.template modEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
+        template <class U> void operator ^=(U && value) { RandomAccess::agent.template xorEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
+        template <class U> void operator &=(U && value) { RandomAccess::agent.template andEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
+        template <class U> void operator |=(U && value) { RandomAccess::agent.template orEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
     };
 
     template <class Agent, class default_index_type, class RootData, class T, class Keys, std::size_t I, class ... Pathway>
@@ -1041,14 +1049,6 @@ namespace RareEdit
                 else
                     RandomAccess::agent.template set<Pathway...>(std::forward<U>(value), (Keys &)(*this));
             }
-            template <class U> void operator +=(U && value) { RandomAccess::agent.template plusEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
-            template <class U> void operator -=(U && value) { RandomAccess::agent.template minusEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
-            template <class U> void operator *=(U && value) { RandomAccess::agent.template multEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
-            template <class U> void operator /=(U && value) { RandomAccess::agent.template divEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
-            template <class U> void operator %=(U && value) { RandomAccess::agent.template modEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
-            template <class U> void operator ^=(U && value) { RandomAccess::agent.template xorEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
-            template <class U> void operator &=(U && value) { RandomAccess::agent.template andEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
-            template <class U> void operator |=(U && value) { RandomAccess::agent.template orEq<Pathway...>(std::forward<U>(value), (Keys &)(*this)); }
 
             template <class SetIndexes, class Value> void set(SetIndexes && indexes, Value && value) { RandomAccess::agent.template setN<Pathway...>(indexes, std::forward<Value>(value), (Keys &)(*this)); }
             template <class U> void append(U && value) {

--- a/include/rarecpp/editor.h
+++ b/include/rarecpp/editor.h
@@ -7269,12 +7269,12 @@ namespace RareEdit
         {
             if ( actionReferenceCount == 0 )
             {
-                if ( redoCount > 0 )
-                    elideRedos();
-
                 if ( actionFirstEvent.empty() || actionFirstEvent.back() < editable.eventOffsets.size() ||
                     (actionFirstEvent.back() & flagElidedRedos) == flagElidedRedos ) // If the last action is empty, and not a marker, no new action is needed
                 {
+                    if ( redoCount > 0 )
+                        elideRedos();
+
                     actionFirstEvent.push_back(editable.eventOffsets.size());
                 }
             }
@@ -7295,12 +7295,12 @@ namespace RareEdit
         auto operator()() { 
             if ( actionReferenceCount == 0 )
             {
-                if ( redoCount > 0 )
-                    elideRedos();
-
                 if ( actionFirstEvent.empty() || actionFirstEvent.back() < editable.eventOffsets.size() ||
                     (actionFirstEvent.back() & flagElidedRedos) == flagElidedRedos ) // If the last action is empty, and not a marker, no new action is needed
                 {
+                    if ( redoCount > 0 )
+                        elideRedos();
+
                     actionFirstEvent.push_back(editable.eventOffsets.size());
                 }
             }

--- a/include/rarecpp/editor.h
+++ b/include/rarecpp/editor.h
@@ -7498,7 +7498,7 @@ namespace RareEdit
                 }
                 break;
                 case Op::Deselect: // .deselect(index)
-                    put(os, ".deselect(").template putIndex<index_type>(os, offset);
+                    put(os, ".deselect(").template putIndex<index_type>(os, offset).put(os, ")");
                     break;
                 case Op::DeselectN:
                 {
@@ -7534,7 +7534,7 @@ namespace RareEdit
                 if constexpr ( !std::is_void_v<element> )
                 {
                     std::size_t size = static_cast<std::size_t>(editable.template readIndex<index_type>(offset));
-                    put(os, ".setN(").template putIndex<index_type>(os, offset).put(os, ", ").template putIndexes<index_type>(os, offset, size).put(os, " = ").template putValue<type, member_type>(os, offset)
+                    put(os, ".setN(").template putIndex<index_type>(os, offset).put(os, ", ").template putIndexes<index_type>(os, offset, size).put(os, ")").put(os, " = ").template putValue<type, member_type>(os, offset)
                         .put(os, ") // ").template putValues<type, member_type>(os, offset, size);
                 }
                 break;
@@ -7655,7 +7655,7 @@ namespace RareEdit
                 }
                 break;
                 case Op::MoveToL:
-                    put(os, ".moveSelectionsTo(").template putIndex<index_type>(os, offset);
+                    put(os, ".moveSelectionsTo(").template putIndex<index_type>(os, offset).put(os, ")");
                     break;
             }
         }

--- a/include/rarecpp/editor.h
+++ b/include/rarecpp/editor.h
@@ -7909,8 +7909,8 @@ namespace RareEdit
                 clearHistory(); // Clear everything
                 return 0;
             }
-            else if ( actions.empty() )
-                throw std::logic_error("Trim history to size called when actions were empty!");
+            else if ( actions.empty() ) // Nothing to trim
+                return 0;
             
             std::size_t totalActions = actions.size();
             std::uint64_t totalSize = 0;
@@ -7975,6 +7975,7 @@ namespace RareEdit
                     }
                 }
             }
+            return totalSize;
         }
 
         // Initializes the stored data with the given input, this initialization is tracked of initTracked is true

--- a/include/rarecpp/editor.h
+++ b/include/rarecpp/editor.h
@@ -7441,22 +7441,21 @@ namespace RareEdit
             }
         }
 
-        std::size_t getCursorIndex()
+        std::size_t getCursorIndex() // One after the index of the last action which hasn't been undone
         {
             return actions.size()-redoSize;
         }
 
-        std::size_t lastUnelidedAction()
+        std::size_t previousCursorIndex() // One after the index of the most recent un-elided action before the current cursor
         {
-            auto i = static_cast<std::ptrdiff_t>(getCursorIndex())-1;
-            for ( ; i>=0; --i )
+            for ( auto i = static_cast<std::ptrdiff_t>(getCursorIndex())-2; i>=0; --i )
             {
                 if ( (actions[static_cast<std::size_t>(i)].firstEventIndex & flagElidedRedos) == flagElidedRedos )
                     i -= static_cast<std::ptrdiff_t>(actions[static_cast<std::size_t>(i)].firstEventIndex & maskElidedRedoSize);
                 else
-                    break;
+                    return i+1;
             }
-            return static_cast<std::size_t>(i < 0 ? 0 : i);
+            return 0;
         }
 
         auto & put(std::ostream & os, auto && value) const

--- a/include/rarecpp/editor.h
+++ b/include/rarecpp/editor.h
@@ -7454,10 +7454,10 @@ namespace RareEdit
                     break;
                 case Op::Assign: // .assign(size, value) // prevValue
                     if constexpr ( !std::is_void_v<element> )
-                        put(os, ".assign(").template putIndex<index_type>(os, offset).template putValue<type, member_type>(os, offset).put(os, ") // ").template putValue<type, member_type>(os, offset);
+                        put(os, ".assign(").template putIndex<index_type>(os, offset).template putValue<element, member_type>(os, offset).put(os, ") // ").template putValue<type, member_type>(os, offset);
                     break;
                 case Op::AssignDefault: // .assign(size, {}) // prevValue
-                    put(os, ".assign(").template putIndex<index_type>(os, offset).template putValue<type, member_type>(os, offset).put(os, ", {}) // ").template putValue<type, member_type>(os, offset);
+                    put(os, ".assign(").template putIndex<index_type>(os, offset).put(os, ", {}) // ").template putValue<type, member_type>(os, offset);
                     break;
                 case Op::ClearSelections: // .clearSelections() // size, selIndexes
                 {

--- a/include/rarecpp/editor.h
+++ b/include/rarecpp/editor.h
@@ -1729,7 +1729,7 @@ namespace RareEdit
                         if ( t.has_value() )
                             return ReadEditPair{*((const U &)t), *editor};
                         else
-                            return ReadEditPair{refNullOpt, *editor);
+                            return ReadEditPair{refNullOpt, *editor};
                     }
                     else if ( t.has_value() )
                         return editorFromPathImpl<Keys, typename std::remove_cvref_t<U>::value_type, LastMember, Pathway...>(*editor, *t, keys, type_tags<PathTraversed..., PathElement>{});

--- a/include/rarecpp/editor.h
+++ b/include/rarecpp/editor.h
@@ -26,6 +26,8 @@ namespace RareEdit
 
     template <typename SizeType> inline constexpr IndexSizeType<SizeType> IndexSize;
 
+    inline constexpr std::nullopt_t refNullOpt = std::nullopt;
+
     template <typename T>
     constexpr auto defaultIndexType()
     {
@@ -1539,7 +1541,8 @@ namespace RareEdit
             {
                 bool hasValue = value.has_value();
                 u8bool::write(events, hasValue);
-                serializeValue<Member>(*value);
+                if ( hasValue )
+                    serializeValue<Member>(*value);
             }
             else if constexpr ( is_flat_mdspan_v<value_type> )
             {
@@ -1722,7 +1725,12 @@ namespace RareEdit
                 if constexpr ( RareTs::is_optional_v<std::remove_cvref_t<U>> )
                 {
                     if constexpr ( sizeof...(Pathway) == 0 )
-                        return ReadEditPair{*((const U &)t), *editor};
+                    {
+                        if ( t.has_value() )
+                            return ReadEditPair{*((const U &)t), *editor};
+                        else
+                            return ReadEditPair{refNullOpt, *editor);
+                    }
                     else if ( t.has_value() )
                         return editorFromPathImpl<Keys, typename std::remove_cvref_t<U>::value_type, LastMember, Pathway...>(*editor, *t, keys, type_tags<PathTraversed..., PathElement>{});
                 }

--- a/include/rarecpp/editor.h
+++ b/include/rarecpp/editor.h
@@ -7316,7 +7316,12 @@ namespace RareEdit
                 std::swap(userData, pendingActionUserData);
 
             return Editor<Tracked>{this};
-        };
+        }
+
+        void replacePendingActionUserData(UserData userData)
+        {
+            std::swap(userData, pendingActionUserData);
+        }
 
         static inline Editor<Tracked> root {nullptr}; // Represents the root of the data structure, used by client code to create paths
 

--- a/include/rarecpp/editor.h
+++ b/include/rarecpp/editor.h
@@ -7195,9 +7195,10 @@ namespace RareEdit
     using AfterActionOp = decltype(std::declval<Usr>().afterAction(std::size_t(0)));
 
     enum class ActionStatus {
-        Undoable = 0x1,
-        ElidedRedo = 0x2,
-        Redoable = 0x4
+        Unknown = 0,
+        Undoable = 1,
+        ElidedRedo = 2,
+        Redoable = 3
     };
 
     struct DataChangeEvent {
@@ -7206,7 +7207,7 @@ namespace RareEdit
         std::vector<std::string> breakdown {};
     };
 
-    struct Action {
+    struct RenderAction {
         ActionStatus actionStatus {};
         std::size_t elisionCount = 0;
         std::vector<DataChangeEvent> changeEvents {};
@@ -7825,7 +7826,7 @@ namespace RareEdit
             dataChangeEvent.summary += ss.str();
         }
 
-        void renderAction(std::size_t actionIndex, Action & action, bool includeEvents = false) const
+        void renderAction(std::size_t actionIndex, RenderAction & action, bool includeEvents = false) const
         {
             action.byteCount = 8;
             action.changeEvents = {};
@@ -7866,13 +7867,13 @@ namespace RareEdit
             }
         }
 
-        std::vector<Action> renderChangeHistory(bool includeEvents = false) const
+        std::vector<RenderAction> renderChangeHistory(bool includeEvents = false) const
         {
-            std::vector<Action> rendering {};
+            std::vector<RenderAction> rendering {};
             std::size_t totalActions = actionFirstEvent.size();
             for ( std::size_t actionIndex=0; actionIndex<totalActions; ++actionIndex )
             {
-                Action & action = rendering.emplace_back();
+                RenderAction & action = rendering.emplace_back();
 
                 renderAction(actionIndex, action, includeEvents);
                 if ( action.actionStatus == ActionStatus::ElidedRedo && action.elisionCount > 0 )

--- a/include/rarecpp/json.h
+++ b/include/rarecpp/json.h
@@ -1956,7 +1956,7 @@ namespace Json
                 if ( context == nullptr )
                     context = std::make_shared<Context>();
 
-                Put::value<Annotations, MockMember<>, statics, PrettyPrint, IndentLevel, Indent, Object, true, Object>(os, *context, obj, obj);
+                Put::value<Annotations, MockMember<Object>, statics, PrettyPrint, IndentLevel, Indent, Object, true, Object>(os, *context, obj, obj);
 
                 return os;
             }


### PR DESCRIPTION
- Finish updates to editor library following full integration with a separate project
- operator= for reflected objects
- Improve editor MDArray support
- Editor operations for initializing history (when empty), clearing history, and trimming history to a given action or size
- Editor support for optionals
- Support for tracking operations performed on sub-elements & recursive sub-elements of sub-elements
- Refactoring to improve naming/reduce name collisions/name confusion & increase code parity where appropriate
- Swap op, set-like ops (+=, -=, *=, /=, %=, ^=, &= and |=)
- Capability to render action/event information
- Recycle the last action if not used
- Actions support attaching user-defined data
- Ability to attach data to collections in tracked objects