### PR TITLE
Json Empty NullArray Assignment & Forward Slashes

### DIFF
--- a/RareCppTest/json_input_test.cpp
+++ b/RareCppTest/json_input_test.cpp
@@ -1335,7 +1335,7 @@ struct VariousValues
         constIntPointerNull(nullptr), constIntPointerToBecomeNull(&integer), constIntPointerValue(&integer),
         intConstPointerNull(nullptr), intConstPointerToBecomeNull(&integer), intConstPointerValue(&integer),
         constIntConstPointerNull(nullptr), constIntConstPointerToBecomeNull(&integer), constIntConstPointerValue(&integer),
-        genericValue(), intVector(), composedObj({}), integerString(0), enumInt(EnumIntEnum::none), replaceableInt(0), boolean(false),
+        genericValue(), genericObjectArray(), intVector(), composedObj({}), integerString(0), enumInt(EnumIntEnum::none), replaceableInt(0), boolean(false),
         str(), mappedTo({}), emptyTuple({}), singleTuple({}), doubleTuple({}), tripleTuple({}), pair({}),
         primitiveKey(), complexKey(), intIntArrayTuple({}), intIntKeyableTuple({}), intIntTupleTuple({}) {}
         
@@ -1365,6 +1365,7 @@ struct VariousValues
     const int* const constIntConstPointerValue;
 
     Json::Object genericValue;
+    Json::ObjectArray genericObjectArray;
     std::vector<int> intVector;
     ComposedObj composedObj;
     NOTE(integerString, Json::Stringify)
@@ -1394,7 +1395,7 @@ struct VariousValues
         constIntPointerNull, constIntPointerToBecomeNull, constIntPointerValue,
         intConstPointerNull, intConstPointerToBecomeNull, intConstPointerValue,
         constIntConstPointerNull, constIntConstPointerToBecomeNull, constIntConstPointerValue,
-        genericValue, intVector, composedObj, integerString, enumInt, replaceableInt, boolean, constant, str, mappedTo,
+        genericValue, genericObjectArray, intVector, composedObj, integerString, enumInt, replaceableInt, boolean, constant, str, mappedTo,
         emptyTuple, singleTuple, doubleTuple, tripleTuple, pair, primitiveKey, complexKey, intIntArrayTuple,
         intIntKeyableTuple, intIntTupleTuple)
 };
@@ -1416,6 +1417,8 @@ TEST_HEADER(JsonInputRead, Value)
     v.constIntPointerNull = nullptr;
     v.constIntPointerToBecomeNull = &anInt;
     v.constIntPointerValue = &anInt;
+
+    v.genericObjectArray.objectArray().assign(2, Json::ObjectValue{});
 
     v.composedObj.a = 0;
     v.integerString = 0;
@@ -1499,6 +1502,10 @@ TEST_HEADER(JsonInputRead, Value)
     Json::Read::value<NoNote, true, Reflect<VariousValues>::MemberType::constIntPointerValue, const int*, VariousValues>(
         constIntPtrValue, Json::defaultContext, c, v, v.constIntPointerValue);
     EXPECT_EQ(999, anInt); // Value should not change
+
+    std::stringstream emptyArrayValue("[],");
+    Json::Read::value<NoNote, true, Reflect<VariousValues>::MemberType::genericObjectArray, Json::ObjectArray, VariousValues>(
+        emptyArrayValue, Json::defaultContext, c, v, v.genericObjectArray);
 
 
     std::stringstream intConstPtrNullptr("null,");

--- a/RareCppTest/json_test.cpp
+++ b/RareCppTest/json_test.cpp
@@ -2581,7 +2581,7 @@ TEST_HEADER(JsonOutputPut, String)
     Json::Output::Put::string(three, "\\");
     EXPECT_STREQ("\"\\\\\"", three.str().c_str());
     Json::Output::Put::string(four, "/");
-    EXPECT_STREQ("\"\\/\"", four.str().c_str());
+    EXPECT_STREQ("\"/\"", four.str().c_str());
     Json::Output::Put::string(five, "\b");
     EXPECT_STREQ("\"\\b\"", five.str().c_str());
     Json::Output::Put::string(six, "\f");
@@ -2597,7 +2597,7 @@ TEST_HEADER(JsonOutputPut, String)
     EXPECT_STREQ("\"\"", ten.str().c_str());
 
     Json::Output::Put::string(eleven, "asdf\"\\/\b\f\n\r\tjkl;");
-    EXPECT_STREQ("\"asdf\\\"\\\\\\/\\b\\f\\n\\r\\tjkl;\"", eleven.str().c_str());
+    EXPECT_STREQ("\"asdf\\\"\\\\/\\b\\f\\n\\r\\tjkl;\"", eleven.str().c_str());
 }
 
 struct OstreamOverloaded {};

--- a/include/rarecpp/json.h
+++ b/include/rarecpp/json.h
@@ -355,7 +355,22 @@ namespace Json
                         if ( allocatedValue == nullptr ) // !is_pointable<T>::value
                             throw NullUnassignable();
                         else if ( value.type() != allocatedValue->type() ) // !is_pointable<T>::value && allocatedValue != nullptr
-                            throw TypeMismatch(value.type(), allocatedValue->type());
+                        {
+                            if ( allocatedValue->type() == Value::Type::NullArray && allocatedValue->arraySize() == 0 ) // 0-sized null arrays may be assigned to any array
+                            {
+                                switch ( value.type() )
+                                {
+                                    case Value::Type::BoolArray: value = T{}; break;
+                                    case Value::Type::NumberArray: value = T{}; break;
+                                    case Value::Type::StringArray: value = T{}; break;
+                                    case Value::Type::ObjectArray: value = T{}; break;
+                                    case Value::Type::MixedArray: value = T{}; break;
+                                    default: throw TypeMismatch(value.type(), allocatedValue->type()); break;
+                                }
+                            }
+                            else
+                                throw TypeMismatch(value.type(), allocatedValue->type());
+                        }
                         else // !is_pointable_v<T> && allocatedValue != nullptr && value.type() == allocatedValue->type()
                         {
                             value = *allocatedValue;
@@ -1449,7 +1464,6 @@ namespace Json
                     {
                     case '\"': os << "\\\""; break;
                     case '\\': os << "\\\\"; break;
-                    case '/': os << "\\/"; break;
                     case '\b': os << "\\b"; break;
                     case '\f': os << "\\f"; break;
                     case '\n': os << "\\n"; break;


### PR DESCRIPTION
- Change to generic Json so empty NullArrays can be assigned to all other array types Fixes #161 
- Unescape forward slash by default, this makes file paths cleaner and easier for users to deal with